### PR TITLE
Add Express backend skeleton

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for Racing Lap Tracker backend
+DATABASE_URL=postgres://user:password@localhost:5432/racing
+JWT_SECRET=your_jwt_secret
+PORT=5000
+UPLOAD_DIR=uploads

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};

--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,0 +1,6 @@
+module.exports = (err, req, res, next) => {
+  console.error(err);
+  const status = err.status || 500;
+  const message = err.message || 'Server Error';
+  res.status(status).json({ message });
+};

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { body, validationResult } = require('express-validator');
+const db = require('../utils/database');
+
+const router = express.Router();
+
+router.post(
+  '/register',
+  [
+    body('username').notEmpty(),
+    body('email').isEmail(),
+    body('password').isLength({ min: 6 }),
+  ],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, email, password } = req.body;
+    try {
+      const hashed = await bcrypt.hash(password, 10);
+      const result = await db.query(
+        'INSERT INTO users (username, email, password_hash) VALUES ($1,$2,$3) RETURNING id, username, email',
+        [username, email, hashed]
+      );
+      const token = jwt.sign({ id: result.rows[0].id }, process.env.JWT_SECRET, {
+        expiresIn: '7d',
+      });
+      res.status(201).json({ user: result.rows[0], token });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.post(
+  '/login',
+  [body('email').isEmail(), body('password').notEmpty()],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { email, password } = req.body;
+    try {
+      const result = await db.query('SELECT * FROM users WHERE email = $1', [email]);
+      if (result.rows.length === 0) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const user = result.rows[0];
+      const match = await bcrypt.compare(password, user.password_hash);
+      if (!match) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const token = jwt.sign({ id: user.id }, process.env.JWT_SECRET, { expiresIn: '7d' });
+      res.json({ token });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+module.exports = router;

--- a/backend/routes/cars.js
+++ b/backend/routes/cars.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const db = require('../utils/database');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  const { gameId } = req.query;
+  try {
+    let result;
+    if (gameId) {
+      result = await db.query('SELECT * FROM cars WHERE game_id = $1 ORDER BY name', [gameId]);
+    } else {
+      result = await db.query('SELECT * FROM cars ORDER BY name');
+    }
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const db = require('../utils/database');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const result = await db.query('SELECT * FROM games ORDER BY name');
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/lapTimes.js
+++ b/backend/routes/lapTimes.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const { body, validationResult } = require('express-validator');
+const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const result = await db.query(
+      'SELECT * FROM lap_times ORDER BY date_submitted DESC LIMIT 100'
+    );
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post(
+  '/',
+  auth,
+  [
+    body('gameId').notEmpty(),
+    body('trackId').notEmpty(),
+    body('layoutId').notEmpty(),
+    body('carId').notEmpty(),
+    body('inputType').notEmpty(),
+    body('timeMs').isInt({ min: 1 }),
+    body('lapDate').notEmpty(),
+  ],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { gameId, trackId, layoutId, carId, inputType, timeMs, lapDate, screenshotUrl } = req.body;
+    try {
+      const result = await db.query(
+        `INSERT INTO lap_times (user_id, game_id, track_id, layout_id, car_id, input_type, time_ms, lap_date, screenshot_url)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+         RETURNING *`,
+        [req.user.id, gameId, trackId, layoutId, carId, inputType, timeMs, lapDate, screenshotUrl || null]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+module.exports = router;

--- a/backend/routes/layouts.js
+++ b/backend/routes/layouts.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const db = require('../utils/database');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  const { trackId } = req.query;
+  try {
+    let result;
+    if (trackId) {
+      result = await db.query('SELECT * FROM layouts WHERE track_id = $1 ORDER BY name', [trackId]);
+    } else {
+      result = await db.query('SELECT * FROM layouts ORDER BY name');
+    }
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/leaderboards.js
+++ b/backend/routes/leaderboards.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const db = require('../utils/database');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  const { gameId, trackId, layoutId } = req.query;
+  if (!gameId || !trackId || !layoutId) {
+    return res.status(400).json({ message: 'gameId, trackId and layoutId are required' });
+  }
+  try {
+    const result = await db.query(
+      `SELECT lt.*, u.username
+       FROM lap_times lt
+       JOIN users u ON lt.user_id = u.id
+       WHERE lt.game_id = $1 AND lt.track_id = $2 AND lt.layout_id = $3
+       ORDER BY time_ms ASC
+       LIMIT 10`,
+      [gameId, trackId, layoutId]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/tracks.js
+++ b/backend/routes/tracks.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const db = require('../utils/database');
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  const { gameId } = req.query;
+  try {
+    let result;
+    if (gameId) {
+      result = await db.query('SELECT * FROM tracks WHERE game_id = $1 ORDER BY name', [gameId]);
+    } else {
+      result = await db.query('SELECT * FROM tracks ORDER BY name');
+    }
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const multer = require('multer');
+const path = require('path');
+const router = express.Router();
+
+const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, uploadDir);
+  },
+  filename: function (req, file, cb) {
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    cb(null, uniqueSuffix + path.extname(file.originalname));
+  },
+});
+const upload = multer({ storage });
+
+router.post('/', upload.single('file'), (req, res) => {
+  res.json({ url: `/uploads/${req.file.filename}` });
+});
+
+module.exports = router;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const router = express.Router();
+
+router.get('/me', auth, async (req, res, next) => {
+  try {
+    const result = await db.query('SELECT id, username, email, is_admin, avatar_url FROM users WHERE id = $1', [req.user.id]);
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/', async (req, res, next) => {
+  try {
+    const result = await db.query('SELECT id, username FROM users');
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const cors = require('cors');
+const helmet = require('helmet');
+const compression = require('compression');
+const rateLimit = require('express-rate-limit');
+const dotenv = require('dotenv');
+
+// Load environment variables
+dotenv.config();
+
+const db = require('./utils/database');
+const authRoutes = require('./routes/auth');
+const userRoutes = require('./routes/users');
+const gameRoutes = require('./routes/games');
+const trackRoutes = require('./routes/tracks');
+const layoutRoutes = require('./routes/layouts');
+const carRoutes = require('./routes/cars');
+const lapTimeRoutes = require('./routes/lapTimes');
+const leaderboardRoutes = require('./routes/leaderboards');
+const uploadRoutes = require('./routes/uploads');
+const errorHandler = require('./middleware/errorHandler');
+
+const app = express();
+
+app.use(helmet());
+app.use(cors());
+app.use(compression());
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+
+// Basic rate limiting
+const limiter = rateLimit({ windowMs: 1 * 60 * 1000, max: 100 });
+app.use(limiter);
+
+// Routes
+app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/games', gameRoutes);
+app.use('/api/tracks', trackRoutes);
+app.use('/api/layouts', layoutRoutes);
+app.use('/api/cars', carRoutes);
+app.use('/api/lapTimes', lapTimeRoutes);
+app.use('/api/leaderboards', leaderboardRoutes);
+app.use('/api/uploads', uploadRoutes);
+
+// Error handling
+app.use(errorHandler);
+
+const PORT = process.env.PORT || 5000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+module.exports = app;

--- a/backend/utils/database.js
+++ b/backend/utils/database.js
@@ -1,0 +1,11 @@
+const { Pool } = require('pg');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  pool,
+};


### PR DESCRIPTION
## Summary
- implement Express server and routing
- add database utility and auth/error middleware
- scaffold all API route handlers
- provide `.env.example` variables

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527f3cdc60832197585f08f84df04f