### PR TITLE
Implement frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ npm-debug.log*
 # Build outputs
 /dist/
 /build/
+frontend/dist/
+frontend/pnpm-lock.yaml
 *.tsbuildinfo
 
 # Environment files

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Racing Lap Tracker</title>
+  </head>
+  <body class="min-h-screen bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,57 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+    --primary: 262.1 83.3% 57.8%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 262.1 83.3% 57.8%;
+  }
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 262.1 83.3% 57.8%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 263.4 70% 50.4%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,17 @@
+import apiClient from './client';
+import { User } from '../types';
+
+export async function login(email: string, password: string): Promise<{ token: string }> {
+  const res = await apiClient.post('/auth/login', { email, password });
+  return res.data;
+}
+
+export async function register(username: string, email: string, password: string): Promise<{ user: User; token: string }> {
+  const res = await apiClient.post('/auth/register', { username, email, password });
+  return res.data;
+}
+
+export async function getCurrentUser(): Promise<User> {
+  const res = await apiClient.get('/users/me');
+  return res.data;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '/api',
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default apiClient;

--- a/frontend/src/api/games.ts
+++ b/frontend/src/api/games.ts
@@ -1,0 +1,11 @@
+import apiClient from './client';
+
+export interface Game {
+  id: number;
+  name: string;
+}
+
+export async function getGames(): Promise<Game[]> {
+  const res = await apiClient.get('/games');
+  return res.data;
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,5 @@
+export * from './auth';
+export * from './games';
+export * from './lapTimes';
+export * from './leaderboards';
+export * from './upload';

--- a/frontend/src/api/lapTimes.ts
+++ b/frontend/src/api/lapTimes.ts
@@ -1,0 +1,12 @@
+import apiClient from './client';
+import { LapTime } from '../types';
+
+export async function getLapTimes(): Promise<LapTime[]> {
+  const res = await apiClient.get('/lapTimes');
+  return res.data;
+}
+
+export async function submitLapTime(data: Omit<LapTime, 'id' | 'userId'>): Promise<LapTime> {
+  const res = await apiClient.post('/lapTimes', data);
+  return res.data;
+}

--- a/frontend/src/api/leaderboards.ts
+++ b/frontend/src/api/leaderboards.ts
@@ -1,0 +1,11 @@
+import apiClient from './client';
+import { LapTime } from '../types';
+
+export async function getLeaderboard(params: {
+  gameId: number;
+  trackId: number;
+  layoutId: number;
+}): Promise<LapTime[]> {
+  const res = await apiClient.get('/leaderboards', { params });
+  return res.data;
+}

--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -1,0 +1,10 @@
+import apiClient from './client';
+
+export async function uploadFile(file: File): Promise<{ url: string }> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await apiClient.post('/uploads', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Footer: React.FC = () => {
+  return (
+    <footer className="border-t py-4 text-center text-sm text-muted-foreground">
+      <p>&copy; {new Date().getFullYear()} Racing Tracker</p>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -92,7 +92,7 @@ const Header: React.FC = () => {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                   <Avatar className="h-8 w-8">
-                    <AvatarImage src={user.avatarUrl} alt={user.username} />
+                    <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
                     <AvatarFallback>{getInitials(user.username)}</AvatarFallback>
                   </Avatar>
                 </Button>

--- a/frontend/src/components/ui/avatar.tsx
+++ b/frontend/src/components/ui/avatar.tsx
@@ -1,0 +1,37 @@
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import React from 'react';
+import { cn } from '../../utils';
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image ref={ref} className={cn('aspect-square h-full w-full', className)} {...props} />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn('flex h-full w-full items-center justify-center rounded-full bg-muted', className)}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cn } from '../../utils';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'ghost';
+  size?: 'default' | 'sm';
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'default', asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:opacity-50',
+          variant === 'default' &&
+            'bg-primary text-primary-foreground hover:bg-primary/90',
+          variant === 'ghost' && 'hover:bg-accent hover:text-accent-foreground',
+          size === 'default' && 'h-10 px-4 py-2',
+          size === 'sm' && 'h-9 px-3',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,131 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import React from 'react';
+import { cn } from '../../utils';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+interface SubTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> {
+  inset?: boolean;
+}
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  SubTriggerProps
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+interface MenuItemProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> {
+  inset?: boolean;
+}
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  MenuItemProps
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+interface MenuLabelProps
+  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> {
+  inset?: boolean;
+}
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  MenuLabelProps
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,37 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import React from 'react';
+import { cn } from '../../utils';
+
+const Sheet = DialogPrimitive.Root;
+const SheetTrigger = DialogPrimitive.Trigger;
+const SheetClose = DialogPrimitive.Close;
+
+interface SheetContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: 'left' | 'right' | 'top' | 'bottom';
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 bg-background p-4 shadow-lg transition-transform',
+        side === 'right' && 'inset-y-0 right-0 w-80 translate-x-0',
+        side === 'left' && 'inset-y-0 left-0 w-80',
+        side === 'top' && 'inset-x-0 top-0 h-1/3',
+        side === 'bottom' && 'inset-x-0 bottom-0 h-1/3',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+SheetContent.displayName = 'SheetContent';
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent };

--- a/frontend/src/components/ui/theme-provider.tsx
+++ b/frontend/src/components/ui/theme-provider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps>({
+  theme: 'light',
+  setTheme: () => {},
+});
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  defaultTheme?: Theme;
+  storageKey?: string;
+}
+
+export const ThemeProvider: React.FC<ThemeProviderProps> = ({
+  children,
+  defaultTheme = 'light',
+  storageKey = 'theme',
+}) => {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return defaultTheme;
+    return ((localStorage.getItem(storageKey) as Theme) || defaultTheme) as Theme;
+  });
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(storageKey, t);
+    }
+  };
+
+  useEffect(() => {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import * as api from '../api';
+import { User } from '../types';
+
+interface AuthContextType {
+  user: User | null;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (username: string, email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType>({
+  user: null,
+  isLoading: true,
+  login: async () => {},
+  register: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchMe = async () => {
+    try {
+      const me = await api.getCurrentUser();
+      setUser(me);
+    } catch {
+      setUser(null);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      fetchMe();
+    } else {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const login = async (email: string, password: string) => {
+    const { token } = await api.login(email, password);
+    localStorage.setItem('token', token);
+    await fetchMe();
+  };
+
+  const register = async (username: string, email: string, password: string) => {
+    const { token } = await api.register(username, email, password);
+    localStorage.setItem('token', token);
+    await fetchMe();
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Settings } from 'lucide-react';
+
+const AdminPage: React.FC = () => {
+  return (
+    <div className="container py-6 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-6">
+        <Settings className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Admin</h1>
+      </div>
+      <p className="text-muted-foreground">Admin functionality coming soon.</p>
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Timer } from 'lucide-react';
+
+const HomePage: React.FC = () => {
+  return (
+    <div className="container py-6 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-6">
+        <Timer className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Racing Lap Tracker</h1>
+      </div>
+      <p className="text-muted-foreground">
+        Track your fastest laps and compete with other drivers.
+      </p>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Timer } from 'lucide-react';
+
+const LapTimesPage: React.FC = () => {
+  return (
+    <div className="container py-6 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-6">
+        <Timer className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Lap Times</h1>
+      </div>
+      <p className="text-muted-foreground">Lap time listings will be added soon.</p>
+    </div>
+  );
+};
+
+export default LapTimesPage;

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Trophy } from 'lucide-react';
+
+const LeaderboardPage: React.FC = () => {
+  return (
+    <div className="container py-6 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-6">
+        <Trophy className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Leaderboard</h1>
+      </div>
+      <p className="text-muted-foreground">Leaderboard functionality coming soon.</p>
+    </div>
+  );
+};
+
+export default LeaderboardPage;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { Button } from '../components/ui/button';
+
+const LoginPage: React.FC = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = (location.state as any)?.from?.pathname || '/';
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await login(email, password);
+      navigate(from, { replace: true });
+    } catch (err: any) {
+      setError(err.message || 'Failed to login');
+    }
+  };
+
+  return (
+    <div className="container max-w-sm py-6">
+      <h1 className="text-2xl font-bold mb-4">Log In</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded border px-3 py-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded border px-3 py-2"
+            required
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+      </form>
+      <p className="text-sm mt-4">
+        Need an account?{' '}
+        <Link to="/register" className="underline">
+          Register
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { Button } from '../components/ui/button';
+
+const RegisterPage: React.FC = () => {
+  const { register: registerUser } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await registerUser(username, email, password);
+      navigate('/');
+    } catch (err: any) {
+      setError(err.message || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="container max-w-sm py-6">
+      <h1 className="text-2xl font-bold mb-4">Register</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && <p className="text-destructive text-sm">{error}</p>}
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Username</label>
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full rounded border px-3 py-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded border px-3 py-2"
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded border px-3 py-2"
+            required
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Register
+        </Button>
+      </form>
+      <p className="text-sm mt-4">
+        Already have an account?{' '}
+        <Link to="/login" className="underline">
+          Login
+        </Link>
+      </p>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { PlusCircle } from 'lucide-react';
+
+const SubmitLapTimePage: React.FC = () => {
+  return (
+    <div className="container py-6 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-6">
+        <PlusCircle className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Submit Lap Time</h1>
+      </div>
+      <p className="text-muted-foreground">Form to submit lap times will be implemented later.</p>
+    </div>
+  );
+};
+
+export default SubmitLapTimePage;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,21 @@
+export interface User {
+  id: number;
+  username: string;
+  email: string;
+  avatarUrl?: string | null;
+  isAdmin?: boolean;
+}
+
+export interface LapTime {
+  id: number;
+  userId: number;
+  gameId: number;
+  trackId: number;
+  layoutId: number;
+  carId: number;
+  inputType: string;
+  timeMs: number;
+  lapDate: string;
+  screenshotUrl?: string | null;
+  username?: string;
+}

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,10 @@
+export * from './cn';
+
+export function getInitials(name: string) {
+  return name
+    .split(' ')
+    .map((n) => n.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,8 @@
+export function formatTime(ms: number) {
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  const milliseconds = ms % 1000;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}.${milliseconds
+    .toString()
+    .padStart(3, '0')}`;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,28 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  darkMode: 'class',
+  content: ['index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: 'hsl(var(--primary))',
+        'primary-foreground': 'hsl(var(--primary-foreground))',
+        secondary: 'hsl(var(--secondary))',
+        'secondary-foreground': 'hsl(var(--secondary-foreground))',
+        muted: 'hsl(var(--muted))',
+        'muted-foreground': 'hsl(var(--muted-foreground))',
+        accent: 'hsl(var(--accent))',
+        'accent-foreground': 'hsl(var(--accent-foreground))',
+        destructive: 'hsl(var(--destructive))',
+        'destructive-foreground': 'hsl(var(--destructive-foreground))',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+} satisfies Config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- set up Vite and Tailwind for the React client
- add theme provider, Button and other ui primitives
- implement authentication context and API helpers
- fill in page components and routing scaffolding
- create basic styling and project configuration

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685280d228b083218ea045f8665298c6