### PR TITLE
Normalize user fields from API

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -6,12 +6,29 @@ export async function login(email: string, password: string): Promise<{ token: s
   return res.data;
 }
 
-export async function register(username: string, email: string, password: string): Promise<{ user: User; token: string }> {
-  const res = await apiClient.post('/auth/register', { username, email, password });
+export async function register(
+  username: string,
+  email: string,
+  password: string
+): Promise<{ user: User; token: string }> {
+  const res = await apiClient.post('/auth/register', {
+    username,
+    email,
+    password,
+  });
+  const { user, token } = res.data;
+  if (user) {
+    const { is_admin, avatar_url, ...rest } = user;
+    return {
+      user: { ...rest, isAdmin: is_admin, avatarUrl: avatar_url },
+      token,
+    };
+  }
   return res.data;
 }
 
 export async function getCurrentUser(): Promise<User> {
   const res = await apiClient.get('/users/me');
-  return res.data;
+  const { is_admin, avatar_url, ...rest } = res.data;
+  return { ...rest, isAdmin: is_admin, avatarUrl: avatar_url };
 }


### PR DESCRIPTION
## Summary
- map `is_admin` and `avatar_url` to camelCase in `getCurrentUser()`
- normalize the same fields in `register()` results

## Testing
- `pnpm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6852884a7d808321bc712925477eabb8