### PR TITLE
Serve uploaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ npm run dev  # or `npm start` for production
 
 Environment variables can be configured in `backend/.env` (see `backend/.env.example`).
 
+Uploaded files are stored in the `backend/uploads` directory by default. The server
+creates this folder automatically on startup and serves its contents at `/uploads`.
+You can change the location by setting the `UPLOAD_DIR` environment variable.
+
 ## Frontend Setup
 
 ```bash

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -19,4 +19,7 @@ router.post('/', upload.single('file'), (req, res) => {
   res.json({ url: `/uploads/${req.file.filename}` });
 });
 
-module.exports = router;
+module.exports = {
+  router,
+  uploadDir,
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
+const fs = require('fs');
 const dotenv = require('dotenv');
 
 // Load environment variables
@@ -17,7 +18,7 @@ const layoutRoutes = require('./routes/layouts');
 const carRoutes = require('./routes/cars');
 const lapTimeRoutes = require('./routes/lapTimes');
 const leaderboardRoutes = require('./routes/leaderboards');
-const uploadRoutes = require('./routes/uploads');
+const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -27,6 +28,10 @@ app.use(cors());
 app.use(compression());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+
+// Ensure uploads directory exists and serve static files
+fs.mkdirSync(uploadDir, { recursive: true });
+app.use('/uploads', express.static(uploadDir));
 
 // Basic rate limiting
 const limiter = rateLimit({ windowMs: 1 * 60 * 1000, max: 100 });


### PR DESCRIPTION
## Summary
- export `uploadDir` from the uploads router and update `server.js` to use it
- create uploads folder automatically and serve it at `/uploads`
- document the uploads folder in the README

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68528a54f36c8321806caee9326f4dfd