### PR TITLE
Add test setup docs and pretest scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ psql -U <user> -d <database> -f database/seed_data.sql
 
 Adjust connection settings in your backend environment variables as needed.
 
+## Running Tests
+
+Before running tests make sure all dependencies are installed:
+
+```bash
+cd backend && npm install
+cd ../frontend && pnpm install
+```
+
+Run the backend and frontend test suites with:
+
+```bash
+npm test      # from ./backend
+pnpm test     # from ./frontend
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "pretest": "test -d node_modules || npm install",
     "test": "jest"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "yes | pnpm install && rm -rf node_modules/.vite-temp && tsc -b && vite build",
     "lint": "yes | pnpm install && eslint .",
     "preview": "yes | pnpm install && vite preview",
+    "pretest": "test -d node_modules || pnpm install",
     "test": "jest"
   },
 "dependencies": {


### PR DESCRIPTION
## Summary
- document running tests with dependency install steps
- add `pretest` scripts to automatically install deps

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68528b64c0988321973000cf67bd38f3