### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ pnpm dev   # starts the Vite dev server
 
 Use `pnpm build` to create a production build.
 
+## Docker Compose
+
+The repository ships with a `docker-compose.yml` configuration for a quick
+development setup. It starts PostgreSQL, the backend API and the frontend app.
+
+1. Copy `backend/.env.example` to `backend/.env` and adjust the variables if
+   needed (especially `JWT_SECRET`).
+2. Run `docker compose up --build` from the project root.
+3. Visit `http://localhost:5173` to access the UI. The API will be available at
+   `http://localhost:5000`.
+
+Database data is stored in the `db-data` volume and uploaded files are kept in
+`backend/uploads`.
+
 ## Database Setup
 
 Create a PostgreSQL database and apply the schema and seed files:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: racing
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/racing
+      JWT_SECRET: supersecret
+      PORT: 5000
+      UPLOAD_DIR: uploads
+    volumes:
+      - ./backend/uploads:/usr/src/app/uploads
+    depends_on:
+      - db
+    ports:
+      - "5000:5000"
+
+  frontend:
+    build: ./frontend
+    environment:
+      VITE_API_URL: http://localhost:5000/api
+    depends_on:
+      - backend
+    ports:
+      - "5173:4173"
+
+volumes:
+  db-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18
+WORKDIR /usr/src/app
+RUN npm install -g pnpm
+COPY pnpm-lock.yaml package.json ./
+RUN pnpm install
+COPY . .
+RUN pnpm build
+EXPOSE 4173
+CMD ["pnpm", "preview", "--host", "--port", "4173"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- provide docker-compose configuration
- document running the project using docker compose

## Testing
- `npm test` from `./backend`
- `pnpm test` from `./frontend`

------
https://chatgpt.com/codex/tasks/task_e_68528ce98b108321b6ab214d8b06f188