### PR TITLE
Update Docker env files and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ frontend/dist/
 .env
 .env.*
 !.env.example
+!.env.production
 
 # Vite cache
 node_modules/.vite

--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ The repository ships with a `docker-compose.yml` configuration for a quick
 development setup. It starts PostgreSQL, the backend API and the frontend app.
 
 1. Copy `backend/.env.example` to `backend/.env` and adjust the variables if
-   needed (especially `JWT_SECRET`).
-2. Run `docker compose up --build` from the project root. Building the images
-   requires internet access. The `frontend/Dockerfile` runs `npm install -g
-   pnpm`, which downloads packages from `registry.npmjs.org`; without a network
-   connection this step fails with `EAI_AGAIN`.
-3. Visit `http://localhost:5173` to access the UI. The API will be available at
+   needed (especially `JWT_SECRET`). The default `DATABASE_URL` points to the
+   `db` service used by Docker Compose.
+2. Copy `frontend/.env.production` and set `VITE_API_URL` to the publicly
+   reachable URL of the backend, for example `http://localhost:5000/api`.
+3. Run `docker compose build --no-cache frontend` followed by
+   `docker compose up -d` from the project root. Building the images requires
+   internet access. The `frontend/Dockerfile` runs `npm install -g pnpm`, which
+   downloads packages from `registry.npmjs.org`; without a network connection
+   this step fails with `EAI_AGAIN`.
+4. Visit `http://localhost:5173` to access the UI. The API will be available at
    `http://localhost:5000`.
 
 Database data is stored in the `db-data` volume and uploaded files are kept in
@@ -60,6 +64,16 @@ Create a PostgreSQL database and apply the schema and seed files:
 ```bash
 psql -U <user> -d <database> -f database/schema.sql
 psql -U <user> -d <database> -f database/seed_data.sql
+```
+
+If you are using the Docker setup and need to seed a fresh container, copy the
+SQL files into the database container and execute them:
+
+```bash
+docker cp ./database/schema.sql <db_container>:/schema.sql
+docker cp ./database/seed_data.sql <db_container>:/seed_data.sql
+docker exec -it <db_container> psql -U postgres -d racing -f /schema.sql
+docker exec -it <db_container> psql -U postgres -d racing -f /seed_data.sql
 ```
 
 Adjust connection settings in your backend environment variables as needed.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,5 @@
 # Example environment variables for Racing Lap Tracker backend
-DATABASE_URL=postgres://user:password@localhost:5432/racing
+DATABASE_URL=postgres://postgres:postgres@db:5432/racing
 JWT_SECRET=your_jwt_secret
 PORT=5000
 UPLOAD_DIR=uploads

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,7 @@ RUN npm install -g pnpm
 COPY pnpm-lock.yaml package.json ./
 RUN pnpm install
 COPY . .
+COPY .env.production .env
 RUN pnpm build
 EXPOSE 4173
 CMD ["pnpm", "preview", "--host", "--port", "4173"]

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- unignore `.env.production`
- switch db host to `db` in backend `.env.example`
- bake frontend env vars during build
- add `vite-env.d.ts`
- document Docker setup, env vars and seeding database

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6852bd5c3160832180d9e727405e3280