### PR TITLE
Add leaderboard images

### DIFF
--- a/backend/routes/leaderboards.js
+++ b/backend/routes/leaderboards.js
@@ -9,9 +9,17 @@ router.get('/', async (req, res, next) => {
   }
   try {
     const result = await db.query(
-      `SELECT lt.*, u.username
+      `SELECT lt.*, u.username,
+              g.name AS game_name, g.image_url AS game_image_url,
+              t.name AS track_name, t.image_url AS track_image_url,
+              l.name AS layout_name, l.image_url AS layout_image_url,
+              c.name AS car_name, c.image_url AS car_image_url
        FROM lap_times lt
        JOIN users u ON lt.user_id = u.id
+       JOIN games g ON lt.game_id = g.id
+       JOIN tracks t ON lt.track_id = t.id
+       JOIN layouts l ON lt.layout_id = l.id
+       JOIN cars c ON lt.car_id = c.id
        WHERE lt.game_id = $1 AND lt.track_id = $2 AND lt.layout_id = $3
        ORDER BY time_ms ASC
        LIMIT 10`,

--- a/frontend/src/pages/LeaderboardPage.test.tsx
+++ b/frontend/src/pages/LeaderboardPage.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../api', () => ({
+  getGames: () => Promise.resolve([]),
+  getTracks: () => Promise.resolve([]),
+  getLayouts: () => Promise.resolve([]),
+  getLeaderboard: () => Promise.resolve([]),
+}));
+
+import LeaderboardPage from './LeaderboardPage';
+
+test('renders leaderboard heading', () => {
+  render(<LeaderboardPage />);
+  expect(screen.getByText(/Leaderboard/i)).toBeInTheDocument();
+});

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,14 +1,160 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Trophy } from 'lucide-react';
+import { getGames, getTracks, getLayouts, getLeaderboard } from '../api';
+import { Game, Track, Layout, LapTime } from '../types';
+import { formatTime } from '../utils/time';
 
 const LeaderboardPage: React.FC = () => {
+  const [games, setGames] = useState<Game[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [layouts, setLayouts] = useState<Layout[]>([]);
+  const [gameId, setGameId] = useState('');
+  const [trackId, setTrackId] = useState('');
+  const [layoutId, setLayoutId] = useState('');
+  const [entries, setEntries] = useState<LapTime[]>([]);
+
+  useEffect(() => {
+    getGames().then(setGames).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (gameId) {
+      getTracks(gameId)
+        .then(setTracks)
+        .catch(() => setTracks([]));
+    } else {
+      setTracks([]);
+      setTrackId('');
+    }
+  }, [gameId]);
+
+  useEffect(() => {
+    if (trackId) {
+      getLayouts(trackId)
+        .then(setLayouts)
+        .catch(() => setLayouts([]));
+    } else {
+      setLayouts([]);
+      setLayoutId('');
+    }
+  }, [trackId]);
+
+  useEffect(() => {
+    if (gameId && trackId && layoutId) {
+      getLeaderboard({ gameId, trackId, layoutId })
+        .then(setEntries)
+        .catch(() => setEntries([]));
+    } else {
+      setEntries([]);
+    }
+  }, [gameId, trackId, layoutId]);
+
   return (
-    <div className="container py-6 text-center">
+    <div className="container py-6">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <Trophy className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Leaderboard</h1>
       </div>
-      <p className="text-muted-foreground">Leaderboard functionality coming soon.</p>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <select
+          value={gameId}
+          onChange={(e) => setGameId(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+        >
+          <option value="">Select game</option>
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={trackId}
+          onChange={(e) => setTrackId(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+          disabled={!gameId}
+        >
+          <option value="">Select track</option>
+          {tracks.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={layoutId}
+          onChange={(e) => setLayoutId(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+          disabled={!trackId}
+        >
+          <option value="">Select layout</option>
+          {layouts.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {entries.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border">
+            <thead>
+              <tr className="border-b">
+                <th className="px-2 py-1">#</th>
+                <th className="px-2 py-1 text-left">Driver</th>
+                <th className="px-2 py-1 text-left">Game</th>
+                <th className="px-2 py-1 text-left">Track</th>
+                <th className="px-2 py-1 text-left">Car</th>
+                <th className="px-2 py-1 text-right">Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e, idx) => (
+                <tr key={e.id} className="border-b last:border-0">
+                  <td className="px-2 py-1 text-center">{idx + 1}</td>
+                  <td className="px-2 py-1">{e.username}</td>
+                  <td className="px-2 py-1">
+                    {e.gameImageUrl && (
+                      <img
+                        src={e.gameImageUrl}
+                        alt={e.gameName || ''}
+                        className="h-8 w-14 object-cover rounded mb-1"
+                      />
+                    )}
+                    {e.gameName}
+                  </td>
+                  <td className="px-2 py-1">
+                    {e.trackImageUrl && (
+                      <img
+                        src={e.trackImageUrl}
+                        alt={e.trackName || ''}
+                        className="h-8 w-14 object-cover rounded mb-1"
+                      />
+                    )}
+                    {e.trackName}
+                    {e.layoutName ? ` - ${e.layoutName}` : ''}
+                  </td>
+                  <td className="px-2 py-1">
+                    {e.carImageUrl && (
+                      <img
+                        src={e.carImageUrl}
+                        alt={e.carName || ''}
+                        className="h-8 w-14 object-cover rounded mb-1"
+                      />
+                    )}
+                    {e.carName}
+                  </td>
+                  <td className="px-2 py-1 text-right">
+                    {formatTime(e.timeMs)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-center text-muted-foreground">No lap times found.</p>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,4 +41,12 @@ export interface LapTime {
   lapDate: string;
   screenshotUrl?: string | null;
   username?: string;
+  gameName?: string;
+  gameImageUrl?: string | null;
+  trackName?: string;
+  trackImageUrl?: string | null;
+  layoutName?: string;
+  layoutImageUrl?: string | null;
+  carName?: string;
+  carImageUrl?: string | null;
 }


### PR DESCRIPTION
## Summary
- extend leaderboard API to include images and names for game, track, layout and car
- show leaderboard data in frontend with track/car/game images
- expand `LapTime` type to cover new fields
- add unit test for LeaderboardPage

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6852c3580ef4832198e19262eae1a4ae