### PR TITLE
Add admin management API and UI

### DIFF
--- a/backend/middleware/admin.js
+++ b/backend/middleware/admin.js
@@ -1,0 +1,13 @@
+const db = require('../utils/database');
+
+module.exports = async function (req, res, next) {
+  try {
+    const result = await db.query('SELECT is_admin FROM users WHERE id = $1', [req.user.id]);
+    if (result.rows[0] && result.rows[0].is_admin) {
+      return next();
+    }
+    return res.status(403).json({ message: 'Admin access required' });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
+
+const router = express.Router();
+
+router.get('/lapTimes/unverified', auth, admin, async (req, res, next) => {
+  try {
+    const result = await db.query(
+      'SELECT * FROM lap_times WHERE verified = FALSE ORDER BY date_submitted DESC'
+    );
+    res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/lapTimes/:id/verify', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query(
+      'UPDATE lap_times SET verified = TRUE WHERE id = $1 RETURNING *',
+      [id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Lap time not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/lapTimes/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query('DELETE FROM lap_times WHERE id = $1 RETURNING *', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Lap time not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/routes/cars.js
+++ b/backend/routes/cars.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -12,6 +14,49 @@ router.get('/', async (req, res, next) => {
       result = await db.query('SELECT * FROM cars ORDER BY name');
     }
     res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', auth, admin, async (req, res, next) => {
+  const { gameId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'INSERT INTO cars (game_id, name, image_url) VALUES ($1,$2,$3) RETURNING *',
+      [gameId, name, imageUrl || null]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  const { gameId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'UPDATE cars SET game_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING *',
+      [gameId, name, imageUrl || null, id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Car not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query('DELETE FROM cars WHERE id=$1 RETURNING *', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Car not found' });
+    }
+    res.json(result.rows[0]);
   } catch (err) {
     next(err);
   }

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -1,11 +1,56 @@
 const express = require('express');
 const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
   try {
     const result = await db.query('SELECT * FROM games ORDER BY name');
     res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', auth, admin, async (req, res, next) => {
+  const { name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'INSERT INTO games (name, image_url) VALUES ($1,$2) RETURNING *',
+      [name, imageUrl || null]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  const { name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'UPDATE games SET name=$1, image_url=$2 WHERE id=$3 RETURNING *',
+      [name, imageUrl || null, id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Game not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query('DELETE FROM games WHERE id=$1 RETURNING *', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Game not found' });
+    }
+    res.json(result.rows[0]);
   } catch (err) {
     next(err);
   }

--- a/backend/routes/layouts.js
+++ b/backend/routes/layouts.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -12,6 +14,49 @@ router.get('/', async (req, res, next) => {
       result = await db.query('SELECT * FROM layouts ORDER BY name');
     }
     res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', auth, admin, async (req, res, next) => {
+  const { trackId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'INSERT INTO layouts (track_id, name, image_url) VALUES ($1,$2,$3) RETURNING *',
+      [trackId, name, imageUrl || null]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  const { trackId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'UPDATE layouts SET track_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING *',
+      [trackId, name, imageUrl || null, id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Layout not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query('DELETE FROM layouts WHERE id=$1 RETURNING *', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Layout not found' });
+    }
+    res.json(result.rows[0]);
   } catch (err) {
     next(err);
   }

--- a/backend/routes/tracks.js
+++ b/backend/routes/tracks.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -12,6 +14,49 @@ router.get('/', async (req, res, next) => {
       result = await db.query('SELECT * FROM tracks ORDER BY name');
     }
     res.json(result.rows);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/', auth, admin, async (req, res, next) => {
+  const { gameId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'INSERT INTO tracks (game_id, name, image_url) VALUES ($1,$2,$3) RETURNING *',
+      [gameId, name, imageUrl || null]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  const { gameId, name, imageUrl } = req.body;
+  try {
+    const result = await db.query(
+      'UPDATE tracks SET game_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING *',
+      [gameId, name, imageUrl || null, id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Track not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  try {
+    const result = await db.query('DELETE FROM tracks WHERE id=$1 RETURNING *', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Track not found' });
+    }
+    res.json(result.rows[0]);
   } catch (err) {
     next(err);
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,7 @@ const layoutRoutes = require('./routes/layouts');
 const carRoutes = require('./routes/cars');
 const lapTimeRoutes = require('./routes/lapTimes');
 const leaderboardRoutes = require('./routes/leaderboards');
+const adminRoutes = require('./routes/admin');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const errorHandler = require('./middleware/errorHandler');
 
@@ -47,14 +48,17 @@ app.use('/api/cars', carRoutes);
 app.use('/api/lapTimes', lapTimeRoutes);
 app.use('/api/leaderboards', leaderboardRoutes);
 app.use('/api/uploads', uploadRoutes);
+app.use('/api/admin', adminRoutes);
 
 // Error handling
 app.use(errorHandler);
 
 const PORT = process.env.PORT || 5000;
 
-app.listen(PORT, () => {
-  console.log(`Server running on port ${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
+}
 
 module.exports = app;

--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const app = require('../server');
+
+jest.mock('../middleware/auth', () => jest.fn((req, res, next) => { req.user = { id: 'admin' }; next(); }));
+jest.mock('../middleware/admin', () => jest.fn((req, res, next) => next()));
+
+jest.mock('../utils/database', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../utils/database');
+
+describe('Admin routes', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  it('lists unverified lap times', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1' }] });
+    const res = await request(app).get('/api/admin/lapTimes/unverified');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: '1' }]);
+    expect(db.query).toHaveBeenCalled();
+  });
+
+  it('verifies a lap time', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1', verified: true }] });
+    const res = await request(app).put('/api/admin/lapTimes/1/verify');
+    expect(res.status).toBe(200);
+    expect(res.body.verified).toBe(true);
+  });
+
+  it('deletes a lap time', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1' }] });
+    const res = await request(app).delete('/api/admin/lapTimes/1');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('1');
+  });
+});

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,0 +1,77 @@
+import apiClient from './client';
+import { LapTime, Game, Track, Layout, Car } from '../types';
+
+export async function getUnverifiedLapTimes(): Promise<LapTime[]> {
+  const res = await apiClient.get('/admin/lapTimes/unverified');
+  return res.data;
+}
+
+export async function verifyLapTime(id: string): Promise<LapTime> {
+  const res = await apiClient.put(`/admin/lapTimes/${id}/verify`);
+  return res.data;
+}
+
+export async function deleteLapTime(id: string): Promise<LapTime> {
+  const res = await apiClient.delete(`/admin/lapTimes/${id}`);
+  return res.data;
+}
+
+export async function createGame(data: Partial<Game>): Promise<Game> {
+  const res = await apiClient.post('/games', data);
+  return res.data;
+}
+
+export async function updateGame(id: string, data: Partial<Game>): Promise<Game> {
+  const res = await apiClient.put(`/games/${id}`, data);
+  return res.data;
+}
+
+export async function deleteGame(id: string): Promise<Game> {
+  const res = await apiClient.delete(`/games/${id}`);
+  return res.data;
+}
+
+export async function createTrack(data: Partial<Track>): Promise<Track> {
+  const res = await apiClient.post('/tracks', data);
+  return res.data;
+}
+
+export async function updateTrack(id: string, data: Partial<Track>): Promise<Track> {
+  const res = await apiClient.put(`/tracks/${id}`, data);
+  return res.data;
+}
+
+export async function deleteTrack(id: string): Promise<Track> {
+  const res = await apiClient.delete(`/tracks/${id}`);
+  return res.data;
+}
+
+export async function createLayout(data: Partial<Layout>): Promise<Layout> {
+  const res = await apiClient.post('/layouts', data);
+  return res.data;
+}
+
+export async function updateLayout(id: string, data: Partial<Layout>): Promise<Layout> {
+  const res = await apiClient.put(`/layouts/${id}`, data);
+  return res.data;
+}
+
+export async function deleteLayout(id: string): Promise<Layout> {
+  const res = await apiClient.delete(`/layouts/${id}`);
+  return res.data;
+}
+
+export async function createCar(data: Partial<Car>): Promise<Car> {
+  const res = await apiClient.post('/cars', data);
+  return res.data;
+}
+
+export async function updateCar(id: string, data: Partial<Car>): Promise<Car> {
+  const res = await apiClient.put(`/cars/${id}`, data);
+  return res.data;
+}
+
+export async function deleteCar(id: string): Promise<Car> {
+  const res = await apiClient.delete(`/cars/${id}`);
+  return res.data;
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './cars';
 export * from './lapTimes';
 export * from './leaderboards';
 export * from './upload';
+export * from './admin';

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+
+jest.mock('../api', () => ({
+  getUnverifiedLapTimes: () => Promise.resolve([]),
+  getGames: () => Promise.resolve([]),
+  getTracks: () => Promise.resolve([]),
+  getLayouts: () => Promise.resolve([]),
+  getCars: () => Promise.resolve([]),
+}));
+
+import AdminPage from './AdminPage';
+
+test('renders admin heading', () => {
+  render(<AdminPage />);
+  expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+});

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,14 +1,367 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Settings } from 'lucide-react';
+import {
+  getUnverifiedLapTimes,
+  verifyLapTime,
+  deleteLapTime,
+  getGames,
+  getTracks,
+  getLayouts,
+  getCars,
+  createGame,
+  updateGame,
+  deleteGame,
+  createTrack,
+  updateTrack,
+  deleteTrack,
+  createLayout,
+  updateLayout,
+  deleteLayout,
+  createCar,
+  updateCar,
+  deleteCar,
+} from '../api';
+import { LapTime, Game, Track, Layout, Car } from '../types';
+import { Button } from '../components/ui/button';
 
 const AdminPage: React.FC = () => {
+  const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
+  const [games, setGames] = useState<Game[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [layouts, setLayouts] = useState<Layout[]>([]);
+  const [cars, setCars] = useState<Car[]>([]);
+
+  const [gameName, setGameName] = useState('');
+  const [selectedGame, setSelectedGame] = useState('');
+
+  const [trackName, setTrackName] = useState('');
+  const [trackGameId, setTrackGameId] = useState('');
+  const [selectedTrack, setSelectedTrack] = useState('');
+
+  const [layoutName, setLayoutName] = useState('');
+  const [layoutTrackId, setLayoutTrackId] = useState('');
+  const [selectedLayout, setSelectedLayout] = useState('');
+
+  const [carName, setCarName] = useState('');
+  const [carGameId, setCarGameId] = useState('');
+  const [selectedCar, setSelectedCar] = useState('');
+
+  useEffect(() => {
+    getUnverifiedLapTimes().then(setLapTimes).catch(() => {});
+    getGames().then(setGames).catch(() => {});
+    getTracks().then(setTracks).catch(() => {});
+    getLayouts().then(setLayouts).catch(() => {});
+    getCars().then(setCars).catch(() => {});
+  }, []);
+
+  const refreshGames = () => getGames().then(setGames).catch(() => {});
+  const refreshTracks = () => getTracks().then(setTracks).catch(() => {});
+  const refreshLayouts = () => getLayouts().then(setLayouts).catch(() => {});
+  const refreshCars = () => getCars().then(setCars).catch(() => {});
+
+  const handleSaveGame = async () => {
+    if (selectedGame) {
+      await updateGame(selectedGame, { name: gameName });
+    } else {
+      await createGame({ name: gameName });
+    }
+    setGameName('');
+    setSelectedGame('');
+    refreshGames();
+  };
+
+  const handleDeleteGame = async () => {
+    if (selectedGame) {
+      await deleteGame(selectedGame);
+      setSelectedGame('');
+      setGameName('');
+      refreshGames();
+    }
+  };
+
+  const handleSaveTrack = async () => {
+    if (selectedTrack) {
+      await updateTrack(selectedTrack, { gameId: trackGameId, name: trackName });
+    } else {
+      await createTrack({ gameId: trackGameId, name: trackName });
+    }
+    setTrackName('');
+    setSelectedTrack('');
+    refreshTracks();
+  };
+
+  const handleDeleteTrack = async () => {
+    if (selectedTrack) {
+      await deleteTrack(selectedTrack);
+      setSelectedTrack('');
+      setTrackName('');
+      refreshTracks();
+    }
+  };
+
+  const handleSaveLayout = async () => {
+    if (selectedLayout) {
+      await updateLayout(selectedLayout, { trackId: layoutTrackId, name: layoutName });
+    } else {
+      await createLayout({ trackId: layoutTrackId, name: layoutName });
+    }
+    setLayoutName('');
+    setSelectedLayout('');
+    refreshLayouts();
+  };
+
+  const handleDeleteLayout = async () => {
+    if (selectedLayout) {
+      await deleteLayout(selectedLayout);
+      setSelectedLayout('');
+      setLayoutName('');
+      refreshLayouts();
+    }
+  };
+
+  const handleSaveCar = async () => {
+    if (selectedCar) {
+      await updateCar(selectedCar, { gameId: carGameId, name: carName });
+    } else {
+      await createCar({ gameId: carGameId, name: carName });
+    }
+    setCarName('');
+    setSelectedCar('');
+    refreshCars();
+  };
+
+  const handleDeleteCar = async () => {
+    if (selectedCar) {
+      await deleteCar(selectedCar);
+      setSelectedCar('');
+      setCarName('');
+      refreshCars();
+    }
+  };
+
+  const verify = async (id: string) => {
+    await verifyLapTime(id);
+    setLapTimes((lt) => lt.filter((l) => l.id !== id));
+  };
+
+  const remove = async (id: string) => {
+    await deleteLapTime(id);
+    setLapTimes((lt) => lt.filter((l) => l.id !== id));
+  };
+
   return (
-    <div className="container py-6 text-center">
-      <div className="flex items-center justify-center space-x-2 mb-6">
+    <div className="container py-6 space-y-8">
+      <div className="flex items-center space-x-2 mb-4">
         <Settings className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Admin</h1>
       </div>
-      <p className="text-muted-foreground">Admin functionality coming soon.</p>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Unverified Lap Times</h2>
+        <table className="w-full text-sm text-left border">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">ID</th>
+              <th className="p-2">Time (ms)</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {lapTimes.map((lt) => (
+              <tr key={lt.id} className="border-b">
+                <td className="p-2">{lt.id}</td>
+                <td className="p-2">{lt.timeMs}</td>
+                <td className="p-2 space-x-2">
+                  <Button size="sm" onClick={() => verify(lt.id)}>Verify</Button>
+                  <Button size="sm" variant="ghost" onClick={() => remove(lt.id)}>
+                    Delete
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {lapTimes.length === 0 && (
+              <tr>
+                <td colSpan={3} className="p-2 text-center text-muted-foreground">
+                  No unverified lap times
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="space-y-6">
+        <div>
+          <h3 className="font-semibold mb-2">Games</h3>
+          <div className="flex space-x-2 mb-2">
+            <select
+              value={selectedGame}
+              onChange={(e) => {
+                const id = e.target.value;
+                setSelectedGame(id);
+                const game = games.find((g) => g.id === id);
+                setGameName(game ? game.name : '');
+              }}
+              className="border p-1"
+            >
+              <option value="">New</option>
+              {games.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+            <input
+              className="border p-1 flex-1"
+              value={gameName}
+              onChange={(e) => setGameName(e.target.value)}
+              placeholder="Name"
+            />
+            <Button size="sm" onClick={handleSaveGame}>Save</Button>
+            <Button size="sm" variant="ghost" onClick={handleDeleteGame}>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Tracks</h3>
+          <div className="flex space-x-2 mb-2">
+            <select
+              value={selectedTrack}
+              onChange={(e) => {
+                const id = e.target.value;
+                setSelectedTrack(id);
+                const track = tracks.find((t) => t.id === id);
+                setTrackName(track ? track.name : '');
+                setTrackGameId(track ? track.gameId : '');
+              }}
+              className="border p-1"
+            >
+              <option value="">New</option>
+              {tracks.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={trackGameId}
+              onChange={(e) => setTrackGameId(e.target.value)}
+              className="border p-1"
+            >
+              <option value="">Game</option>
+              {games.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+            <input
+              className="border p-1 flex-1"
+              value={trackName}
+              onChange={(e) => setTrackName(e.target.value)}
+              placeholder="Name"
+            />
+            <Button size="sm" onClick={handleSaveTrack}>Save</Button>
+            <Button size="sm" variant="ghost" onClick={handleDeleteTrack}>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Layouts</h3>
+          <div className="flex space-x-2 mb-2">
+            <select
+              value={selectedLayout}
+              onChange={(e) => {
+                const id = e.target.value;
+                setSelectedLayout(id);
+                const layout = layouts.find((l) => l.id === id);
+                setLayoutName(layout ? layout.name : '');
+                setLayoutTrackId(layout ? layout.trackId : '');
+              }}
+              className="border p-1"
+            >
+              <option value="">New</option>
+              {layouts.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={layoutTrackId}
+              onChange={(e) => setLayoutTrackId(e.target.value)}
+              className="border p-1"
+            >
+              <option value="">Track</option>
+              {tracks.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+            <input
+              className="border p-1 flex-1"
+              value={layoutName}
+              onChange={(e) => setLayoutName(e.target.value)}
+              placeholder="Name"
+            />
+            <Button size="sm" onClick={handleSaveLayout}>Save</Button>
+            <Button size="sm" variant="ghost" onClick={handleDeleteLayout}>
+              Delete
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="font-semibold mb-2">Cars</h3>
+          <div className="flex space-x-2 mb-2">
+            <select
+              value={selectedCar}
+              onChange={(e) => {
+                const id = e.target.value;
+                setSelectedCar(id);
+                const car = cars.find((c) => c.id === id);
+                setCarName(car ? car.name : '');
+                setCarGameId(car ? car.gameId : '');
+              }}
+              className="border p-1"
+            >
+              <option value="">New</option>
+              {cars.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <select
+              value={carGameId}
+              onChange={(e) => setCarGameId(e.target.value)}
+              className="border p-1"
+            >
+              <option value="">Game</option>
+              {games.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+            <input
+              className="border p-1 flex-1"
+              value={carName}
+              onChange={(e) => setCarName(e.target.value)}
+              placeholder="Name"
+            />
+            <Button size="sm" onClick={handleSaveCar}>Save</Button>
+            <Button size="sm" variant="ghost" onClick={handleDeleteCar}>
+              Delete
+            </Button>
+          </div>
+        </div>
+      </section>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow admin verification of lap times via new backend routes
- add CRUD operations for games, tracks, layouts and cars
- expose new admin API methods to the frontend
- implement basic admin interface with lap time moderation and entity forms
- include unit tests for admin routes and render test for Admin page

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685343cd956483219c4fc182995dce2a