### PR TITLE
Add coverage for auth, lap submission and admin routes

### DIFF
--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -36,4 +36,28 @@ describe('Admin routes', () => {
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('1');
   });
+  it('creates a game', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1' }] });
+    const res = await request(app)
+      .post('/api/games')
+      .send({ name: 'Test Game' });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe('1');
+  });
+
+  it('updates a track', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '2', name: 'Updated' }] });
+    const res = await request(app)
+      .put('/api/tracks/2')
+      .send({ gameId: '1', name: 'Updated' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Updated');
+  });
+
+  it('deletes a car', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '3' }] });
+    const res = await request(app).delete('/api/cars/3');
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe('3');
+  });
 });

--- a/backend/tests/authRoutes.test.js
+++ b/backend/tests/authRoutes.test.js
@@ -1,0 +1,58 @@
+const request = require('supertest');
+const app = require('../server');
+
+jest.mock('../utils/database', () => ({
+  query: jest.fn(),
+}));
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(() => Promise.resolve('hashed')),
+  compare: jest.fn(() => Promise.resolve(true)),
+}));
+
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(() => 'jwt'),
+}));
+
+const db = require('../utils/database');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+describe('Auth routes', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+    bcrypt.hash.mockClear();
+    bcrypt.compare.mockClear();
+    jwt.sign.mockClear();
+  });
+
+  it('registers a user', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1', username: 'test', email: 'a@b.co' }] });
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ username: 'test', email: 'a@b.co', password: 'secret' });
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBe('jwt');
+    expect(db.query).toHaveBeenCalled();
+    expect(bcrypt.hash).toHaveBeenCalled();
+    expect(jwt.sign).toHaveBeenCalled();
+  });
+
+  it('logs in a user', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1', password_hash: 'hashed' }] });
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'a@b.co', password: 'secret' });
+    expect(res.status).toBe(200);
+    expect(res.body.token).toBe('jwt');
+    expect(bcrypt.compare).toHaveBeenCalled();
+  });
+
+  it('rejects invalid login', async () => {
+    db.query.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'x@y.co', password: 'bad' });
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/tests/lapTimesRoutes.test.js
+++ b/backend/tests/lapTimesRoutes.test.js
@@ -1,0 +1,37 @@
+const request = require('supertest');
+const app = require('../server');
+
+jest.mock('../middleware/auth', () => jest.fn((req, res, next) => {
+  req.user = { id: 'user1' };
+  next();
+}));
+
+jest.mock('../utils/database', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../utils/database');
+
+describe('Lap time routes', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  it('submits a lap time', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: '1' }] });
+    const res = await request(app)
+      .post('/api/lapTimes')
+      .send({
+        gameId: 'g1',
+        trackId: 't1',
+        layoutId: 'l1',
+        carId: 'c1',
+        inputType: 'Wheel',
+        timeMs: 1234,
+        lapDate: '2024-01-01',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe('1');
+    expect(db.query).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import ProtectedRoute from './ProtectedRoute';
+
+jest.mock('../../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('ProtectedRoute', () => {
+  it('redirects unauthenticated users', () => {
+    mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    render(
+      <MemoryRouter initialEntries={['/private']}>
+        <Routes>
+          <Route path="/private" element={<ProtectedRoute><div>Private</div></ProtectedRoute>} />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Login')).toBeInTheDocument();
+  });
+
+  it('shows access denied for non-admin', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: false }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/admin" element={<ProtectedRoute requireAdmin><div>Admin</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+  });
+
+  it('renders children for authorised admin', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: true }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Routes>
+          <Route path="/admin" element={<ProtectedRoute requireAdmin><div>Admin</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -1,16 +1,47 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-jest.mock('../api', () => ({
-  getUnverifiedLapTimes: () => Promise.resolve([]),
-  getGames: () => Promise.resolve([]),
-  getTracks: () => Promise.resolve([]),
-  getLayouts: () => Promise.resolve([]),
-  getCars: () => Promise.resolve([]),
-}));
+const mockedApi = {
+  getUnverifiedLapTimes: jest.fn(),
+  getGames: jest.fn(),
+  getTracks: jest.fn(),
+  getLayouts: jest.fn(),
+  getCars: jest.fn(),
+  verifyLapTime: jest.fn(),
+  deleteLapTime: jest.fn(),
+};
+
+jest.mock('../api', () => mockedApi);
 
 import AdminPage from './AdminPage';
+
+beforeEach(() => {
+  mockedApi.getUnverifiedLapTimes.mockResolvedValue([]);
+  mockedApi.getGames.mockResolvedValue([]);
+  mockedApi.getTracks.mockResolvedValue([]);
+  mockedApi.getLayouts.mockResolvedValue([]);
+  mockedApi.getCars.mockResolvedValue([]);
+});
 
 test('renders admin heading', () => {
   render(<AdminPage />);
   expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+});
+
+test('verifies a lap time', async () => {
+  mockedApi.getUnverifiedLapTimes.mockResolvedValue([{ id: '1', timeMs: 123 }]);
+  mockedApi.verifyLapTime.mockResolvedValue({ id: '1', verified: true });
+  render(<AdminPage />);
+  expect(await screen.findByText('1')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /verify/i }));
+  expect(mockedApi.verifyLapTime).toHaveBeenCalledWith('1');
+});
+
+test('deletes a lap time', async () => {
+  mockedApi.getUnverifiedLapTimes.mockResolvedValue([{ id: '2', timeMs: 456 }]);
+  mockedApi.deleteLapTime.mockResolvedValue({ id: '2' });
+  render(<AdminPage />);
+  expect(await screen.findByText('2')).toBeInTheDocument();
+  await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
+  expect(mockedApi.deleteLapTime).toHaveBeenCalledWith('2');
 });

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as ReactRouter from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import LoginPage from './LoginPage';
+
+jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const navigate = jest.fn();
+(ReactRouter.useNavigate as jest.Mock).mockReturnValue(navigate);
+(ReactRouter.useLocation as jest.Mock).mockReturnValue({ state: { from: { pathname: '/dest' } } });
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({ login: jest.fn(), register: jest.fn(), logout: jest.fn(), user: null, isLoading: false });
+    navigate.mockClear();
+  });
+
+  it('submits credentials and navigates', async () => {
+    const loginMock = jest.fn();
+    mockedUseAuth.mockReturnValue({ login: loginMock, register: jest.fn(), logout: jest.fn(), user: null, isLoading: false });
+    render(
+      <ReactRouter.MemoryRouter>
+        <LoginPage />
+      </ReactRouter.MemoryRouter>
+    );
+    await userEvent.type(screen.getAllByRole('textbox')[0], 'a@b.c');
+    const passwordInput = screen.getByText('Password').parentElement!.querySelector('input')!;
+    await userEvent.type(passwordInput, 'secret');
+    await userEvent.click(screen.getByRole('button', { name: /login/i }));
+    expect(loginMock).toHaveBeenCalledWith('a@b.c', 'secret');
+    expect(navigate).toHaveBeenCalledWith('/dest', { replace: true });
+  });
+});


### PR DESCRIPTION
## Summary
- test authentication routes
- test lap time submission
- extend admin route tests for CRUD operations
- add ProtectedRoute tests
- cover login page behaviour
- expand Admin page tests for verify/delete actions

## Testing
- `npm test --silent` in `backend`
- `pnpm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685346be255883218a96e801d2676ddb