### PR TITLE
Add comprehensive lap times page

### DIFF
--- a/backend/tests/lapTimesRoutes.test.js
+++ b/backend/tests/lapTimesRoutes.test.js
@@ -34,4 +34,12 @@ describe('Lap time routes', () => {
     expect(res.body.id).toBe('1');
     expect(db.query).toHaveBeenCalled();
   });
+
+  it('lists world records', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: 'r1' }] });
+    const res = await request(app).get('/api/lapTimes/records');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'r1' }]);
+    expect(db.query).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/api/lapTimes.ts
+++ b/frontend/src/api/lapTimes.ts
@@ -1,8 +1,13 @@
 import apiClient from './client';
 import { LapTime } from '../types';
 
-export async function getLapTimes(): Promise<LapTime[]> {
-  const res = await apiClient.get('/lapTimes');
+export async function getLapTimes(userId?: string): Promise<LapTime[]> {
+  const res = await apiClient.get('/lapTimes', { params: userId ? { userId } : undefined });
+  return res.data;
+}
+
+export async function getWorldRecords(): Promise<LapTime[]> {
+  const res = await apiClient.get('/lapTimes/records');
   return res.data;
 }
 

--- a/frontend/src/pages/LapTimesPage.test.tsx
+++ b/frontend/src/pages/LapTimesPage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../api', () => ({
+  getLapTimes: () => Promise.resolve([]),
+  getWorldRecords: () => Promise.resolve([]),
+}));
+
+jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+
+import LapTimesPage from './LapTimesPage';
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+beforeEach(() => {
+  mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+});
+
+test('renders lap times heading', () => {
+  render(<LapTimesPage />);
+  expect(screen.getByRole('heading', { name: /Lap Times/i })).toBeInTheDocument();
+});

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -1,14 +1,133 @@
-import React from 'react';
-import { Timer } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Timer, Crown, Users } from 'lucide-react';
+import { getLapTimes, getWorldRecords } from '../api';
+import { LapTime } from '../types';
+import { formatTime } from '../utils/time';
+import { useAuth } from '../contexts/AuthContext';
 
 const LapTimesPage: React.FC = () => {
+  const { user } = useAuth();
+  const [myLaps, setMyLaps] = useState<LapTime[]>([]);
+  const [otherLaps, setOtherLaps] = useState<LapTime[]>([]);
+  const [records, setRecords] = useState<LapTime[]>([]);
+
+  useEffect(() => {
+    getLapTimes()
+      .then((data) => {
+        if (user) {
+          setMyLaps(data.filter((l) => l.userId === user.id));
+          setOtherLaps(data.filter((l) => l.userId !== user.id));
+        } else {
+          setOtherLaps(data);
+        }
+      })
+      .catch(() => {});
+    getWorldRecords()
+      .then(setRecords)
+      .catch(() => {});
+  }, [user]);
+
+  const renderTable = (laps: LapTime[]) => (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm border">
+        <thead>
+          <tr className="border-b">
+            <th className="px-2 py-1 text-left">Driver</th>
+            <th className="px-2 py-1 text-left">Game</th>
+            <th className="px-2 py-1 text-left">Track</th>
+            <th className="px-2 py-1 text-left">Car</th>
+            <th className="px-2 py-1 text-right">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {laps.map((l) => (
+            <tr key={l.id} className="border-b last:border-0">
+              <td className="px-2 py-1">{l.username}</td>
+              <td className="px-2 py-1">
+                {l.gameImageUrl && (
+                  <img
+                    src={l.gameImageUrl}
+                    alt={l.gameName || ''}
+                    className="h-8 w-14 object-cover rounded mb-1"
+                  />
+                )}
+                {l.gameName}
+              </td>
+              <td className="px-2 py-1">
+                {l.trackImageUrl && (
+                  <img
+                    src={l.trackImageUrl}
+                    alt={l.trackName || ''}
+                    className="h-8 w-14 object-cover rounded mb-1"
+                  />
+                )}
+                {l.trackName}
+                {l.layoutName ? ` - ${l.layoutName}` : ''}
+              </td>
+              <td className="px-2 py-1">
+                {l.carImageUrl && (
+                  <img
+                    src={l.carImageUrl}
+                    alt={l.carName || ''}
+                    className="h-8 w-14 object-cover rounded mb-1"
+                  />
+                )}
+                {l.carName}
+              </td>
+              <td className="px-2 py-1 text-right">{formatTime(l.timeMs)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
   return (
-    <div className="container py-6 text-center">
+    <div className="container py-6 space-y-8">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <Timer className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Lap Times</h1>
       </div>
-      <p className="text-muted-foreground">Lap time listings will be added soon.</p>
+
+      <section>
+        <div className="flex items-center space-x-2 mb-2">
+          <Crown className="h-5 w-5" />
+          <h2 className="text-xl font-semibold">World Records</h2>
+        </div>
+        {records.length > 0 ? (
+          renderTable(records)
+        ) : (
+          <p className="text-center text-muted-foreground">No records found.</p>
+        )}
+      </section>
+
+      {user && (
+        <section>
+          <div className="flex items-center space-x-2 mb-2">
+            <Timer className="h-5 w-5" />
+            <h2 className="text-xl font-semibold">Your Lap Times</h2>
+          </div>
+          {myLaps.length > 0 ? (
+            renderTable(myLaps)
+          ) : (
+            <p className="text-center text-muted-foreground">
+              You have not submitted any laps.
+            </p>
+          )}
+        </section>
+      )}
+
+      <section>
+        <div className="flex items-center space-x-2 mb-2">
+          <Users className="h-5 w-5" />
+          <h2 className="text-xl font-semibold">Other Users</h2>
+        </div>
+        {otherLaps.length > 0 ? (
+          renderTable(otherLaps)
+        ) : (
+          <p className="text-center text-muted-foreground">No lap times found.</p>
+        )}
+      </section>
     </div>
   );
 };

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { User } from 'lucide-react';
+
 const ProfilePage: React.FC = () => {
   return (
     <div className="container py-6">
@@ -11,7 +12,7 @@ const ProfilePage: React.FC = () => {
         <User className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Profile</h1>
       </div>
-      
+
       <div className="text-center py-12 text-muted-foreground">
         <User className="h-16 w-16 mx-auto mb-4 opacity-50" />
         <h2 className="text-xl font-semibold mb-2">Profile Coming Soon</h2>
@@ -20,4 +21,5 @@ const ProfilePage: React.FC = () => {
     </div>
   );
 };
+
 export default ProfilePage;


### PR DESCRIPTION
## Summary
- expand lap time routes to include details and records
- implement lap time record fetching API on frontend
- build new Lap Times page with record and user tables
- add tests for new page and route
- fix profile page file ending

## Testing
- `npm test` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68534c6060a08321aef81cf1f332dc6e