### PR TITLE
Add user profile support

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { body, validationResult } = require('express-validator');
 const db = require('../utils/database');
 const auth = require('../middleware/auth');
 const router = express.Router();
@@ -7,6 +8,61 @@ router.get('/me', auth, async (req, res, next) => {
   try {
     const result = await db.query('SELECT id, username, email, is_admin, avatar_url FROM users WHERE id = $1', [req.user.id]);
     res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.put(
+  '/me',
+  auth,
+  [body('username').optional().notEmpty(), body('avatarUrl').optional().isString()],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, avatarUrl } = req.body;
+    const fields = [];
+    const params = [];
+    if (username) {
+      params.push(username);
+      fields.push(`username = $${params.length}`);
+    }
+    if (avatarUrl !== undefined) {
+      params.push(avatarUrl);
+      fields.push(`avatar_url = $${params.length}`);
+    }
+    if (fields.length === 0) {
+      return res.status(400).json({ message: 'No fields provided' });
+    }
+    params.push(req.user.id);
+    try {
+      const result = await db.query(
+        `UPDATE users SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${
+          params.length
+        } RETURNING id, username, email, is_admin, avatar_url`,
+        params
+      );
+      res.json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.get('/me/stats', auth, async (req, res, next) => {
+  try {
+    const result = await db.query(
+      `SELECT COUNT(*) AS lap_count, MIN(time_ms) AS best_lap_ms, AVG(time_ms)::INT AS avg_lap_ms FROM lap_times WHERE user_id = $1`,
+      [req.user.id]
+    );
+    const row = result.rows[0];
+    res.json({
+      lapCount: parseInt(row.lap_count, 10),
+      bestLapMs: row.best_lap_ms ? parseInt(row.best_lap_ms, 10) : null,
+      avgLapMs: row.avg_lap_ms ? parseInt(row.avg_lap_ms, 10) : null,
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/tests/userRoutes.test.js
+++ b/backend/tests/userRoutes.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const app = require('../server');
+
+jest.mock('../middleware/auth', () => jest.fn((req, res, next) => { req.user = { id: 'u1' }; next(); }));
+
+jest.mock('../utils/database', () => ({ query: jest.fn() }));
+
+const db = require('../utils/database');
+
+describe('User routes', () => {
+  beforeEach(() => {
+    db.query.mockReset();
+  });
+
+  it('updates profile', async () => {
+    db.query.mockResolvedValue({ rows: [{ id: 'u1', username: 'test', email: 'a@b.c', is_admin: false, avatar_url: '/uploads/a.jpg' }] });
+    const res = await request(app).put('/api/users/me').send({ avatarUrl: '/uploads/a.jpg' });
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalled();
+    expect(res.body.avatar_url).toBe('/uploads/a.jpg');
+  });
+
+  it('returns user stats', async () => {
+    db.query.mockResolvedValue({ rows: [{ lap_count: '3', best_lap_ms: 1000, avg_lap_ms: 1500 }] });
+    const res = await request(app).get('/api/users/me/stats');
+    expect(res.status).toBe(200);
+    expect(res.body.lapCount).toBe(3);
+    expect(db.query).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -7,3 +7,4 @@ export * from './lapTimes';
 export * from './leaderboards';
 export * from './upload';
 export * from './admin';
+export * from './users';

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,13 @@
+import apiClient from './client';
+import { User, UserStats } from '../types';
+
+export async function updateProfile(data: { username?: string; avatarUrl?: string }): Promise<User> {
+  const res = await apiClient.put('/users/me', data);
+  const { is_admin, avatar_url, ...rest } = res.data;
+  return { ...rest, isAdmin: is_admin, avatarUrl: avatar_url };
+}
+
+export async function getUserStats(): Promise<UserStats> {
+  const res = await apiClient.get('/users/me/stats');
+  return res.data;
+}

--- a/frontend/src/components/auth/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.test.tsx
@@ -8,7 +8,7 @@ const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('ProtectedRoute', () => {
   it('redirects unauthenticated users', () => {
-    mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
     render(
       <MemoryRouter initialEntries={['/private']}>
         <Routes>
@@ -21,7 +21,7 @@ describe('ProtectedRoute', () => {
   });
 
   it('shows access denied for non-admin', () => {
-    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: false }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: false }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
     render(
       <MemoryRouter initialEntries={['/admin']}>
         <Routes>
@@ -33,7 +33,7 @@ describe('ProtectedRoute', () => {
   });
 
   it('renders children for authorised admin', () => {
-    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: true }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+    mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e', isAdmin: true }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
     render(
       <MemoryRouter initialEntries={['/admin']}>
         <Routes>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   register: (username: string, email: string, password: string) => Promise<void>;
   logout: () => void;
+  refreshUser: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -16,6 +17,7 @@ const AuthContext = createContext<AuthContextType>({
   login: async () => {},
   register: async () => {},
   logout: () => {},
+  refreshUser: async () => {},
 });
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -59,8 +61,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(null);
   };
 
+  const refreshUser = async () => {
+    await fetchMe();
+  };
+
   return (
-    <AuthContext.Provider value={{ user, isLoading, login, register, logout }}>
+    <AuthContext.Provider
+      value={{ user, isLoading, login, register, logout, refreshUser }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/LapTimesPage.test.tsx
+++ b/frontend/src/pages/LapTimesPage.test.tsx
@@ -13,7 +13,7 @@ import LapTimesPage from './LapTimesPage';
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 beforeEach(() => {
-  mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn() });
+  mockedUseAuth.mockReturnValue({ user: null, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
 });
 
 test('renders lap times heading', () => {

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -18,13 +18,13 @@ const navigate = jest.fn();
 
 describe('LoginPage', () => {
   beforeEach(() => {
-    mockedUseAuth.mockReturnValue({ login: jest.fn(), register: jest.fn(), logout: jest.fn(), user: null, isLoading: false });
+    mockedUseAuth.mockReturnValue({ login: jest.fn(), register: jest.fn(), logout: jest.fn(), user: null, isLoading: false, refreshUser: jest.fn() });
     navigate.mockClear();
   });
 
   it('submits credentials and navigates', async () => {
     const loginMock = jest.fn();
-    mockedUseAuth.mockReturnValue({ login: loginMock, register: jest.fn(), logout: jest.fn(), user: null, isLoading: false });
+    mockedUseAuth.mockReturnValue({ login: loginMock, register: jest.fn(), logout: jest.fn(), user: null, isLoading: false, refreshUser: jest.fn() });
     render(
       <ReactRouter.MemoryRouter>
         <LoginPage />

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import ProfilePage from './ProfilePage';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+jest.mock('../api', () => ({ getUserStats: () => Promise.resolve({ lapCount: 0, bestLapMs: null, avgLapMs: null }), uploadFile: jest.fn(), updateProfile: jest.fn() }));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+beforeEach(() => {
+  mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e' }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
+});
+
+test('renders profile heading', async () => {
+  render(<ProfilePage />);
+  expect(screen.getByText(/Profile/i)).toBeInTheDocument();
+});

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,23 +1,78 @@
-/**
- * Profile Page Component
- * Created by MiniMax Agent
- */
-import React from 'react';
-import { User } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { User as UserIcon } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { uploadFile, updateProfile, getUserStats } from '../api';
+import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
+import { Button } from '../components/ui/button';
+import { getInitials } from '../utils';
+import { formatTime } from '../utils/time';
+import { UserStats } from '../types';
 
 const ProfilePage: React.FC = () => {
+  const { user, refreshUser } = useAuth();
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    getUserStats().then(setStats).catch(() => {});
+  }, []);
+
+  const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const { url } = await uploadFile(file);
+      await updateProfile({ avatarUrl: url });
+      await refreshUser();
+    } catch {
+      // ignore errors for now
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  if (!user) return null;
+
   return (
-    <div className="container py-6">
-      <div className="flex items-center space-x-2 mb-6">
-        <User className="h-6 w-6" />
+    <div className="container py-6 space-y-6 max-w-md">
+      <div className="flex items-center space-x-2 mb-4">
+        <UserIcon className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Profile</h1>
       </div>
-
-      <div className="text-center py-12 text-muted-foreground">
-        <User className="h-16 w-16 mx-auto mb-4 opacity-50" />
-        <h2 className="text-xl font-semibold mb-2">Profile Coming Soon</h2>
-        <p>The user profile functionality will be implemented in the next phase.</p>
+      <div className="flex flex-col items-center space-y-3">
+        <Avatar className="h-24 w-24">
+          <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
+          <AvatarFallback className="text-2xl">
+            {getInitials(user.username)}
+          </AvatarFallback>
+        </Avatar>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleAvatarChange}
+          disabled={uploading}
+        />
+        <div className="text-center">
+          <p className="font-semibold text-lg">{user.username}</p>
+          <p className="text-sm text-muted-foreground">{user.email}</p>
+        </div>
       </div>
+      {stats && (
+        <div className="border rounded p-4 space-y-2 text-sm">
+          <p>
+            <span className="font-medium">Total Laps:</span> {stats.lapCount}
+          </p>
+          <p>
+            <span className="font-medium">Best Lap:</span>{' '}
+            {stats.bestLapMs !== null ? formatTime(stats.bestLapMs) : 'N/A'}
+          </p>
+          <p>
+            <span className="font-medium">Average Lap:</span>{' '}
+            {stats.avgLapMs !== null ? formatTime(stats.avgLapMs) : 'N/A'}
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,6 +6,12 @@ export interface User {
   isAdmin?: boolean;
 }
 
+export interface UserStats {
+  lapCount: number;
+  bestLapMs: number | null;
+  avgLapMs: number | null;
+}
+
 export interface Game {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- implement update and stats endpoints in users route
- expose profile API helpers on the frontend
- extend auth context with a refresh method
- build Profile page to upload avatars and show stats
- add Jest tests for new endpoints and components

## Testing
- `npm test --prefix backend`
- `pnpm --dir frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68535242a2008321841df2249eaeaaa1