### PR TITLE
Center page content

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -47,7 +47,7 @@ const Header: React.FC = () => {
   ];
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-16 items-center">
+      <div className="container mx-auto flex h-16 items-center">
         {/* Logo */}
         <Link to="/" className="flex items-center space-x-2 mr-6">
           <Timer className="h-6 w-6" />

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -150,7 +150,7 @@ const AdminPage: React.FC = () => {
   };
 
   return (
-    <div className="container py-6 space-y-8">
+    <div className="container mx-auto py-6 space-y-8">
       <div className="flex items-center space-x-2 mb-4">
         <Settings className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Admin</h1>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import { Timer } from 'lucide-react';
 
 const HomePage: React.FC = () => {
   return (
-    <div className="container py-6 text-center">
+    <div className="container mx-auto py-6 text-center">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <Timer className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Racing Lap Tracker</h1>

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -83,7 +83,7 @@ const LapTimesPage: React.FC = () => {
   );
 
   return (
-    <div className="container py-6 space-y-8">
+    <div className="container mx-auto py-6 space-y-8">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <Timer className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Lap Times</h1>

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -50,7 +50,7 @@ const LeaderboardPage: React.FC = () => {
   }, [gameId, trackId, layoutId]);
 
   return (
-    <div className="container py-6">
+    <div className="container mx-auto py-6">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <Trophy className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Leaderboard</h1>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -25,7 +25,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="container max-w-sm py-6">
+    <div className="container mx-auto max-w-sm py-6">
       <h1 className="text-2xl font-bold mb-4">Log In</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <p className="text-destructive text-sm">{error}</p>}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -35,7 +35,7 @@ const ProfilePage: React.FC = () => {
   if (!user) return null;
 
   return (
-    <div className="container py-6 space-y-6 max-w-md">
+    <div className="container mx-auto py-6 space-y-6 max-w-md">
       <div className="flex items-center space-x-2 mb-4">
         <UserIcon className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Profile</h1>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -23,7 +23,7 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <div className="container max-w-sm py-6">
+    <div className="container mx-auto max-w-sm py-6">
       <h1 className="text-2xl font-bold mb-4">Register</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         {error && <p className="text-destructive text-sm">{error}</p>}

--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -98,7 +98,7 @@ const SubmitLapTimePage: React.FC = () => {
   };
 
   return (
-    <div className="container max-w-md py-6">
+    <div className="container mx-auto max-w-md py-6">
       <div className="flex items-center justify-center space-x-2 mb-6">
         <PlusCircle className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Submit Lap Time</h1>


### PR DESCRIPTION
## Summary
- improve layout by adding `mx-auto` to page containers and header

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68535556d0f08321b1221e0ad6b2a698