### PR TITLE
Improve admin features with uploads

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -8,7 +8,27 @@ const router = express.Router();
 router.get('/lapTimes/unverified', auth, admin, async (req, res, next) => {
   try {
     const result = await db.query(
-      'SELECT * FROM lap_times WHERE verified = FALSE ORDER BY date_submitted DESC'
+      `SELECT lt.id,
+              lt.user_id AS "userId",
+              lt.game_id AS "gameId",
+              lt.track_id AS "trackId",
+              lt.layout_id AS "layoutId",
+              lt.car_id AS "carId",
+              lt.time_ms AS "timeMs",
+              lt.screenshot_url AS "screenshotUrl",
+              u.username,
+              g.name AS "gameName",
+              t.name AS "trackName",
+              l.name AS "layoutName",
+              c.name AS "carName"
+       FROM lap_times lt
+       JOIN users u ON lt.user_id = u.id
+       JOIN games g ON lt.game_id = g.id
+       JOIN tracks t ON lt.track_id = t.id
+       JOIN layouts l ON lt.layout_id = l.id
+       JOIN cars c ON lt.car_id = c.id
+       WHERE lt.verified = FALSE
+       ORDER BY lt.date_submitted DESC`
     );
     res.json(result.rows);
   } catch (err) {

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -1,12 +1,17 @@
 const express = require('express');
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 const router = express.Router();
 
 const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, uploadDir);
+    const sub = req.query.folder
+      ? path.join(uploadDir, req.query.folder)
+      : uploadDir;
+    fs.mkdirSync(sub, { recursive: true });
+    cb(null, sub);
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
@@ -16,7 +21,8 @@ const storage = multer.diskStorage({
 const upload = multer({ storage });
 
 router.post('/', upload.single('file'), (req, res) => {
-  res.json({ url: `/uploads/${req.file.filename}` });
+  const folder = req.query.folder ? `${req.query.folder}/` : '';
+  res.json({ url: `/uploads/${folder}${req.file.filename}` });
 });
 
 module.exports = {

--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -16,10 +16,10 @@ describe('Admin routes', () => {
   });
 
   it('lists unverified lap times', async () => {
-    db.query.mockResolvedValue({ rows: [{ id: '1' }] });
+    db.query.mockResolvedValue({ rows: [{ id: '1', username: 'u1' }] });
     const res = await request(app).get('/api/admin/lapTimes/unverified');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ id: '1' }]);
+    expect(res.body[0].username).toBe('u1');
     expect(db.query).toHaveBeenCalled();
   });
 

--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -1,9 +1,13 @@
 import apiClient from './client';
 
-export async function uploadFile(file: File): Promise<{ url: string }> {
+export async function uploadFile(
+  file: File,
+  folder?: string
+): Promise<{ url: string }> {
   const formData = new FormData();
   formData.append('file', file);
-  const res = await apiClient.post('/uploads', formData, {
+  const url = folder ? `/uploads?folder=${encodeURIComponent(folder)}` : '/uploads';
+  const res = await apiClient.post(url, formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
   return res.data;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -20,9 +20,11 @@ import {
   createCar,
   updateCar,
   deleteCar,
+  uploadFile,
 } from '../api';
 import { LapTime, Game, Track, Layout, Car } from '../types';
 import { Button } from '../components/ui/button';
+import { formatTime } from '../utils/time';
 
 const AdminPage: React.FC = () => {
   const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
@@ -30,6 +32,11 @@ const AdminPage: React.FC = () => {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [layouts, setLayouts] = useState<Layout[]>([]);
   const [cars, setCars] = useState<Car[]>([]);
+
+  const [gameImage, setGameImage] = useState<File | null>(null);
+  const [trackImage, setTrackImage] = useState<File | null>(null);
+  const [layoutImage, setLayoutImage] = useState<File | null>(null);
+  const [carImage, setCarImage] = useState<File | null>(null);
 
   const [gameName, setGameName] = useState('');
   const [selectedGame, setSelectedGame] = useState('');
@@ -60,10 +67,16 @@ const AdminPage: React.FC = () => {
   const refreshCars = () => getCars().then(setCars).catch(() => {});
 
   const handleSaveGame = async () => {
+    let imageUrl: string | undefined;
+    if (gameImage) {
+      const { url } = await uploadFile(gameImage, 'images/games');
+      imageUrl = url;
+      setGameImage(null);
+    }
     if (selectedGame) {
-      await updateGame(selectedGame, { name: gameName });
+      await updateGame(selectedGame, { name: gameName, imageUrl });
     } else {
-      await createGame({ name: gameName });
+      await createGame({ name: gameName, imageUrl });
     }
     setGameName('');
     setSelectedGame('');
@@ -80,10 +93,16 @@ const AdminPage: React.FC = () => {
   };
 
   const handleSaveTrack = async () => {
+    let imageUrl: string | undefined;
+    if (trackImage) {
+      const { url } = await uploadFile(trackImage, 'images/tracks');
+      imageUrl = url;
+      setTrackImage(null);
+    }
     if (selectedTrack) {
-      await updateTrack(selectedTrack, { gameId: trackGameId, name: trackName });
+      await updateTrack(selectedTrack, { gameId: trackGameId, name: trackName, imageUrl });
     } else {
-      await createTrack({ gameId: trackGameId, name: trackName });
+      await createTrack({ gameId: trackGameId, name: trackName, imageUrl });
     }
     setTrackName('');
     setSelectedTrack('');
@@ -100,10 +119,16 @@ const AdminPage: React.FC = () => {
   };
 
   const handleSaveLayout = async () => {
+    let imageUrl: string | undefined;
+    if (layoutImage) {
+      const { url } = await uploadFile(layoutImage, 'images/layouts');
+      imageUrl = url;
+      setLayoutImage(null);
+    }
     if (selectedLayout) {
-      await updateLayout(selectedLayout, { trackId: layoutTrackId, name: layoutName });
+      await updateLayout(selectedLayout, { trackId: layoutTrackId, name: layoutName, imageUrl });
     } else {
-      await createLayout({ trackId: layoutTrackId, name: layoutName });
+      await createLayout({ trackId: layoutTrackId, name: layoutName, imageUrl });
     }
     setLayoutName('');
     setSelectedLayout('');
@@ -120,10 +145,16 @@ const AdminPage: React.FC = () => {
   };
 
   const handleSaveCar = async () => {
+    let imageUrl: string | undefined;
+    if (carImage) {
+      const { url } = await uploadFile(carImage, 'images/cars');
+      imageUrl = url;
+      setCarImage(null);
+    }
     if (selectedCar) {
-      await updateCar(selectedCar, { gameId: carGameId, name: carName });
+      await updateCar(selectedCar, { gameId: carGameId, name: carName, imageUrl });
     } else {
-      await createCar({ gameId: carGameId, name: carName });
+      await createCar({ gameId: carGameId, name: carName, imageUrl });
     }
     setCarName('');
     setSelectedCar('');
@@ -162,7 +193,12 @@ const AdminPage: React.FC = () => {
           <thead>
             <tr className="border-b">
               <th className="p-2">ID</th>
-              <th className="p-2">Time (ms)</th>
+              <th className="p-2">Driver</th>
+              <th className="p-2">Game</th>
+              <th className="p-2">Track</th>
+              <th className="p-2">Car</th>
+              <th className="p-2">Time</th>
+              <th className="p-2">Screenshot</th>
               <th className="p-2">Actions</th>
             </tr>
           </thead>
@@ -170,7 +206,19 @@ const AdminPage: React.FC = () => {
             {lapTimes.map((lt) => (
               <tr key={lt.id} className="border-b">
                 <td className="p-2">{lt.id}</td>
-                <td className="p-2">{lt.timeMs}</td>
+                <td className="p-2">{lt.username}</td>
+                <td className="p-2">{lt.gameName}</td>
+                <td className="p-2">
+                  {lt.trackName}
+                  {lt.layoutName ? ` - ${lt.layoutName}` : ''}
+                </td>
+                <td className="p-2">{lt.carName}</td>
+                <td className="p-2">{formatTime(lt.timeMs)}</td>
+                <td className="p-2">
+                  {lt.screenshotUrl && (
+                    <img src={lt.screenshotUrl} className="h-12" />
+                  )}
+                </td>
                 <td className="p-2 space-x-2">
                   <Button size="sm" onClick={() => verify(lt.id)}>Verify</Button>
                   <Button size="sm" variant="ghost" onClick={() => remove(lt.id)}>
@@ -181,7 +229,7 @@ const AdminPage: React.FC = () => {
             ))}
             {lapTimes.length === 0 && (
               <tr>
-                <td colSpan={3} className="p-2 text-center text-muted-foreground">
+                <td colSpan={8} className="p-2 text-center text-muted-foreground">
                   No unverified lap times
                 </td>
               </tr>
@@ -216,6 +264,11 @@ const AdminPage: React.FC = () => {
               value={gameName}
               onChange={(e) => setGameName(e.target.value)}
               placeholder="Name"
+            />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setGameImage(e.target.files?.[0] || null)}
             />
             <Button size="sm" onClick={handleSaveGame}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteGame}>
@@ -263,6 +316,11 @@ const AdminPage: React.FC = () => {
               onChange={(e) => setTrackName(e.target.value)}
               placeholder="Name"
             />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setTrackImage(e.target.files?.[0] || null)}
+            />
             <Button size="sm" onClick={handleSaveTrack}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteTrack}>
               Delete
@@ -309,6 +367,11 @@ const AdminPage: React.FC = () => {
               onChange={(e) => setLayoutName(e.target.value)}
               placeholder="Name"
             />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setLayoutImage(e.target.files?.[0] || null)}
+            />
             <Button size="sm" onClick={handleSaveLayout}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteLayout}>
               Delete
@@ -354,6 +417,11 @@ const AdminPage: React.FC = () => {
               value={carName}
               onChange={(e) => setCarName(e.target.value)}
               placeholder="Name"
+            />
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(e) => setCarImage(e.target.files?.[0] || null)}
             />
             <Button size="sm" onClick={handleSaveCar}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteCar}>


### PR DESCRIPTION
## Summary
- show more info for unverified lap times
- support foldered uploads and expose new upload API
- add optional image upload when managing games, tracks, layouts and cars
- update admin routes test for new behaviour

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853582240748321beb39bd414461e9e