### PR TITLE
Fix imageUrl property in types

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,24 +15,28 @@ export interface UserStats {
 export interface Game {
   id: string;
   name: string;
+  imageUrl?: string | null;
 }
 
 export interface Track {
   id: string;
   gameId: string;
   name: string;
+  imageUrl?: string | null;
 }
 
 export interface Layout {
   id: string;
   trackId: string;
   name: string;
+  imageUrl?: string | null;
 }
 
 export interface Car {
   id: string;
   gameId: string;
   name: string;
+  imageUrl?: string | null;
 }
 
 export interface LapTime {


### PR DESCRIPTION
## Summary
- include optional `imageUrl` fields in frontend type definitions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68535afdb8a88321b3eeffa971984550