### PR TITLE
Fix uploaded image handling

### DIFF
--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -5,24 +5,48 @@ const fs = require('fs');
 const router = express.Router();
 
 const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
+function sanitizeFilename(name) {
+  return name
+    .replace(/[^a-z0-9._-]/gi, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toLowerCase();
+}
+
 const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    const sub = req.query.folder
-      ? path.join(uploadDir, req.query.folder)
-      : uploadDir;
+  destination(req, file, cb) {
+    const folder = req.query.folder
+      ? path
+          .normalize(req.query.folder)
+          .replace(/^([.]{2}[\/])+/g, '')
+      : '';
+    const sub = path.join(uploadDir, folder);
     fs.mkdirSync(sub, { recursive: true });
     cb(null, sub);
   },
-  filename: function (req, file, cb) {
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    cb(null, uniqueSuffix + path.extname(file.originalname));
+  filename(req, file, cb) {
+    const custom = req.query.filename
+      ? sanitizeFilename(req.query.filename)
+      : null;
+    const ext = path.extname(custom || file.originalname) || '.bin';
+    const name =
+      custom && path.extname(custom)
+        ? custom
+        : custom
+        ? `${custom}${ext}`
+        : `${Date.now()}-${Math.round(Math.random() * 1e9)}${ext}`;
+    cb(null, name);
   },
 });
 const upload = multer({ storage });
 
 router.post('/', upload.single('file'), (req, res) => {
-  const folder = req.query.folder ? `${req.query.folder}/` : '';
-  res.json({ url: `/uploads/${folder}${req.file.filename}` });
+  const folder = req.query.folder
+    ? path.normalize(req.query.folder).replace(/^([.]{2}[\/])+/g, '')
+    : '';
+  const base = `${req.protocol}://${req.get('host')}`;
+  const prefix = folder ? `${folder}/` : '';
+  res.json({ url: `${base}/uploads/${prefix}${req.file.filename}` });
 });
 
 module.exports = {

--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -2,11 +2,16 @@ import apiClient from './client';
 
 export async function uploadFile(
   file: File,
-  folder?: string
+  folder?: string,
+  filename?: string
 ): Promise<{ url: string }> {
   const formData = new FormData();
   formData.append('file', file);
-  const url = folder ? `/uploads?folder=${encodeURIComponent(folder)}` : '/uploads';
+  const params = new URLSearchParams();
+  if (folder) params.append('folder', folder);
+  if (filename) params.append('filename', filename);
+  const query = params.toString();
+  const url = query ? `/uploads?${query}` : '/uploads';
   const res = await apiClient.post(url, formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -25,6 +25,7 @@ import {
 import { LapTime, Game, Track, Layout, Car } from '../types';
 import { Button } from '../components/ui/button';
 import { formatTime } from '../utils/time';
+import { slugify } from '../utils';
 
 const AdminPage: React.FC = () => {
   const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
@@ -69,7 +70,9 @@ const AdminPage: React.FC = () => {
   const handleSaveGame = async () => {
     let imageUrl: string | undefined;
     if (gameImage) {
-      const { url } = await uploadFile(gameImage, 'images/games');
+      const ext = gameImage.name.substring(gameImage.name.lastIndexOf('.'));
+      const filename = `${slugify(gameName)}${ext}`;
+      const { url } = await uploadFile(gameImage, 'images/games', filename);
       imageUrl = url;
       setGameImage(null);
     }
@@ -95,7 +98,9 @@ const AdminPage: React.FC = () => {
   const handleSaveTrack = async () => {
     let imageUrl: string | undefined;
     if (trackImage) {
-      const { url } = await uploadFile(trackImage, 'images/tracks');
+      const ext = trackImage.name.substring(trackImage.name.lastIndexOf('.'));
+      const filename = `${slugify(trackName)}${ext}`;
+      const { url } = await uploadFile(trackImage, 'images/tracks', filename);
       imageUrl = url;
       setTrackImage(null);
     }
@@ -121,7 +126,9 @@ const AdminPage: React.FC = () => {
   const handleSaveLayout = async () => {
     let imageUrl: string | undefined;
     if (layoutImage) {
-      const { url } = await uploadFile(layoutImage, 'images/layouts');
+      const ext = layoutImage.name.substring(layoutImage.name.lastIndexOf('.'));
+      const filename = `${slugify(layoutName)}${ext}`;
+      const { url } = await uploadFile(layoutImage, 'images/layouts', filename);
       imageUrl = url;
       setLayoutImage(null);
     }
@@ -147,7 +154,9 @@ const AdminPage: React.FC = () => {
   const handleSaveCar = async () => {
     let imageUrl: string | undefined;
     if (carImage) {
-      const { url } = await uploadFile(carImage, 'images/cars');
+      const ext = carImage.name.substring(carImage.name.lastIndexOf('.'));
+      const filename = `${slugify(carName)}${ext}`;
+      const { url } = await uploadFile(carImage, 'images/cars', filename);
       imageUrl = url;
       setCarImage(null);
     }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -22,7 +22,9 @@ const ProfilePage: React.FC = () => {
     if (!file) return;
     setUploading(true);
     try {
-      const { url } = await uploadFile(file);
+      const ext = file.name.substring(file.name.lastIndexOf('.'));
+      const filename = `user_${user?.id ?? 'avatar'}${ext}`;
+      const { url } = await uploadFile(file, 'images/avatars', filename);
       await updateProfile({ avatarUrl: url });
       await refreshUser();
     } catch {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './cn';
+export * from './slug';
 
 export function getInitials(name: string) {
   return name

--- a/frontend/src/utils/slug.ts
+++ b/frontend/src/utils/slug.ts
@@ -1,0 +1,7 @@
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+


### PR DESCRIPTION
## Summary
- sanitize upload paths and support custom filenames
- return absolute URL for uploaded files
- allow filename param in frontend upload API
- rename uploaded game, track, layout, car and avatar images based on slug
- export new `slugify` utility

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68535e8ec724832194b55268391a7f12