### PR TITLE
Add admin DB export/import & fix image cache

### DIFF
--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -60,4 +60,26 @@ describe('Admin routes', () => {
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('3');
   });
+
+  it('exports the database', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/admin/export');
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalledTimes(6);
+  });
+
+  it('imports the database', async () => {
+    db.query.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/admin/import')
+      .send({ users: [], games: [], tracks: [], layouts: [], cars: [], lap_times: [] });
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -75,7 +75,7 @@ const AdminPage: React.FC = () => {
     let imageUrl: string | undefined;
     if (gameImage) {
       const ext = gameImage.name.substring(gameImage.name.lastIndexOf('.'));
-      const filename = `${slugify(gameName)}${ext}`;
+      const filename = `${slugify(gameName)}-${Date.now()}${ext}`;
       const { url } = await uploadFile(gameImage, 'images/games', filename);
       imageUrl = url;
       setGameImage(null);
@@ -105,7 +105,7 @@ const AdminPage: React.FC = () => {
     let imageUrl: string | undefined;
     if (trackImage) {
       const ext = trackImage.name.substring(trackImage.name.lastIndexOf('.'));
-      const filename = `${slugify(trackName)}${ext}`;
+      const filename = `${slugify(trackName)}-${Date.now()}${ext}`;
       const { url } = await uploadFile(trackImage, 'images/tracks', filename);
       imageUrl = url;
       setTrackImage(null);
@@ -135,7 +135,7 @@ const AdminPage: React.FC = () => {
     let imageUrl: string | undefined;
     if (layoutImage) {
       const ext = layoutImage.name.substring(layoutImage.name.lastIndexOf('.'));
-      const filename = `${slugify(layoutName)}${ext}`;
+      const filename = `${slugify(layoutName)}-${Date.now()}${ext}`;
       const { url } = await uploadFile(layoutImage, 'images/layouts', filename);
       imageUrl = url;
       setLayoutImage(null);
@@ -165,7 +165,7 @@ const AdminPage: React.FC = () => {
     let imageUrl: string | undefined;
     if (carImage) {
       const ext = carImage.name.substring(carImage.name.lastIndexOf('.'));
-      const filename = `${slugify(carName)}${ext}`;
+      const filename = `${slugify(carName)}-${Date.now()}${ext}`;
       const { url } = await uploadFile(carImage, 'images/cars', filename);
       imageUrl = url;
       setCarImage(null);


### PR DESCRIPTION
## Summary
- add database export and import endpoints to the admin API
- append timestamps to uploaded filenames so new images are used across the site
- test new admin endpoints

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68536bd2ca708321ba073ca1b402d65b