### PR TITLE
Add admin DB export/import UI

### DIFF
--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -60,4 +60,26 @@ describe('Admin routes', () => {
     expect(res.status).toBe(200);
     expect(res.body.id).toBe('3');
   });
+
+  it('exports the database', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get('/api/admin/export');
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalledTimes(6);
+  });
+
+  it('imports the database', async () => {
+    db.query.mockResolvedValue({});
+    const res = await request(app)
+      .post('/api/admin/import')
+      .send({ users: [], games: [], tracks: [], layouts: [], cars: [], lap_times: [] });
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -75,3 +75,13 @@ export async function deleteCar(id: string): Promise<Car> {
   const res = await apiClient.delete(`/cars/${id}`);
   return res.data;
 }
+
+export async function exportDatabase(): Promise<any> {
+  const res = await apiClient.get('/admin/export');
+  return res.data;
+}
+
+export async function importDatabase(data: any): Promise<{ message: string }> {
+  const res = await apiClient.post('/admin/import', data);
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- support DB export and import from the frontend admin API
- add export/import controls to the Admin page UI

## Testing
- `pnpm test` from `frontend`
- `npm test` from `backend` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68536bd2ca708321ba073ca1b402d65b