### PR TITLE
Fix uploaded image URLs

### DIFF
--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -44,9 +44,8 @@ router.post('/', upload.single('file'), (req, res) => {
   const folder = req.query.folder
     ? path.normalize(req.query.folder).replace(/^([.]{2}[\/])+/g, '')
     : '';
-  const base = `${req.protocol}://${req.get('host')}`;
   const prefix = folder ? `${folder}/` : '';
-  res.json({ url: `${base}/uploads/${prefix}${req.file.filename}` });
+  res.json({ url: `/uploads/${prefix}${req.file.filename}` });
 });
 
 module.exports = {

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -28,7 +28,7 @@ import {
 } from '../ui/dropdown-menu';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { Sheet, SheetContent, SheetTrigger } from '../ui/sheet';
-import { getInitials } from '../../utils';
+import { getInitials, getImageUrl } from '../../utils';
 const Header: React.FC = () => {
   const { user, logout } = useAuth();
   const { theme, setTheme } = useTheme();
@@ -92,7 +92,10 @@ const Header: React.FC = () => {
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                   <Avatar className="h-8 w-8">
-                    <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
+                    <AvatarImage
+                      src={getImageUrl(user.avatarUrl) || undefined}
+                      alt={user.username}
+                    />
                     <AvatarFallback>{getInitials(user.username)}</AvatarFallback>
                   </Avatar>
                 </Button>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './App.css';
 
+(window as any).__API_BASE_URL__ = import.meta.env.VITE_API_URL || '';
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -27,7 +27,7 @@ import {
 import { LapTime, Game, Track, Layout, Car } from '../types';
 import { Button } from '../components/ui/button';
 import { formatTime } from '../utils/time';
-import { slugify } from '../utils';
+import { slugify, getImageUrl } from '../utils';
 
 const AdminPage: React.FC = () => {
   const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
@@ -274,7 +274,7 @@ const AdminPage: React.FC = () => {
                 <td className="p-2">{formatTime(lt.timeMs)}</td>
                 <td className="p-2">
                   {lt.screenshotUrl && (
-                    <img src={lt.screenshotUrl} className="h-12" />
+                    <img src={getImageUrl(lt.screenshotUrl)} className="h-12" />
                   )}
                 </td>
                 <td className="p-2 space-x-2">
@@ -334,7 +334,7 @@ const AdminPage: React.FC = () => {
               }}
             />
             {gamePreview && (
-              <img src={gamePreview} alt="preview" className="h-10" />
+              <img src={getImageUrl(gamePreview)} alt="preview" className="h-10" />
             )}
             <Button size="sm" onClick={handleSaveGame}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteGame}>
@@ -393,7 +393,7 @@ const AdminPage: React.FC = () => {
               }}
             />
             {trackPreview && (
-              <img src={trackPreview} alt="preview" className="h-10" />
+              <img src={getImageUrl(trackPreview)} alt="preview" className="h-10" />
             )}
             <Button size="sm" onClick={handleSaveTrack}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteTrack}>
@@ -452,7 +452,7 @@ const AdminPage: React.FC = () => {
               }}
             />
             {layoutPreview && (
-              <img src={layoutPreview} alt="preview" className="h-10" />
+              <img src={getImageUrl(layoutPreview)} alt="preview" className="h-10" />
             )}
             <Button size="sm" onClick={handleSaveLayout}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteLayout}>
@@ -511,7 +511,7 @@ const AdminPage: React.FC = () => {
               }}
             />
             {carPreview && (
-              <img src={carPreview} alt="preview" className="h-10" />
+              <img src={getImageUrl(carPreview)} alt="preview" className="h-10" />
             )}
             <Button size="sm" onClick={handleSaveCar}>Save</Button>
             <Button size="sm" variant="ghost" onClick={handleDeleteCar}>

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -4,6 +4,7 @@ import { getLapTimes, getWorldRecords } from '../api';
 import { LapTime } from '../types';
 import { formatTime } from '../utils/time';
 import { useAuth } from '../contexts/AuthContext';
+import { getImageUrl } from '../utils';
 
 const LapTimesPage: React.FC = () => {
   const { user } = useAuth();
@@ -46,7 +47,7 @@ const LapTimesPage: React.FC = () => {
               <td className="px-2 py-1">
                 {l.gameImageUrl && (
                   <img
-                    src={l.gameImageUrl}
+                    src={getImageUrl(l.gameImageUrl)}
                     alt={l.gameName || ''}
                     className="h-8 w-14 object-cover rounded mb-1"
                   />
@@ -56,7 +57,7 @@ const LapTimesPage: React.FC = () => {
               <td className="px-2 py-1">
                 {l.trackImageUrl && (
                   <img
-                    src={l.trackImageUrl}
+                    src={getImageUrl(l.trackImageUrl)}
                     alt={l.trackName || ''}
                     className="h-8 w-14 object-cover rounded mb-1"
                   />
@@ -67,7 +68,7 @@ const LapTimesPage: React.FC = () => {
               <td className="px-2 py-1">
                 {l.carImageUrl && (
                   <img
-                    src={l.carImageUrl}
+                    src={getImageUrl(l.carImageUrl)}
                     alt={l.carName || ''}
                     className="h-8 w-14 object-cover rounded mb-1"
                   />

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Trophy } from 'lucide-react';
 import { getGames, getTracks, getLayouts, getLeaderboard } from '../api';
+import { getImageUrl } from '../utils';
 import { Game, Track, Layout, LapTime } from '../types';
 import { formatTime } from '../utils/time';
 
@@ -116,7 +117,7 @@ const LeaderboardPage: React.FC = () => {
                   <td className="px-2 py-1">
                     {e.gameImageUrl && (
                       <img
-                        src={e.gameImageUrl}
+                        src={getImageUrl(e.gameImageUrl)}
                         alt={e.gameName || ''}
                         className="h-8 w-14 object-cover rounded mb-1"
                       />
@@ -126,7 +127,7 @@ const LeaderboardPage: React.FC = () => {
                   <td className="px-2 py-1">
                     {e.trackImageUrl && (
                       <img
-                        src={e.trackImageUrl}
+                        src={getImageUrl(e.trackImageUrl)}
                         alt={e.trackName || ''}
                         className="h-8 w-14 object-cover rounded mb-1"
                       />
@@ -137,7 +138,7 @@ const LeaderboardPage: React.FC = () => {
                   <td className="px-2 py-1">
                     {e.carImageUrl && (
                       <img
-                        src={e.carImageUrl}
+                        src={getImageUrl(e.carImageUrl)}
                         alt={e.carName || ''}
                         className="h-8 w-14 object-cover rounded mb-1"
                       />

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { uploadFile, updateProfile, getUserStats } from '../api';
 import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
 import { Button } from '../components/ui/button';
-import { getInitials } from '../utils';
+import { getInitials, getImageUrl } from '../utils';
 import { formatTime } from '../utils/time';
 import { UserStats } from '../types';
 
@@ -44,7 +44,10 @@ const ProfilePage: React.FC = () => {
       </div>
       <div className="flex flex-col items-center space-y-3">
         <Avatar className="h-24 w-24">
-          <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
+          <AvatarImage
+            src={getImageUrl(user.avatarUrl) || undefined}
+            alt={user.username}
+          />
           <AvatarFallback className="text-2xl">
             {getInitials(user.username)}
           </AvatarFallback>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -9,3 +9,13 @@ export function getInitials(name: string) {
     .slice(0, 2)
     .toUpperCase();
 }
+
+export function getImageUrl(path?: string | null) {
+  if (!path) return undefined;
+  if (/^https?:\/\//i.test(path)) return path;
+  if (!path.startsWith('/uploads')) return path;
+  const envBase =
+    (globalThis as any).__API_BASE_URL__ || process.env.VITE_API_URL || '';
+  const base = (envBase || '').replace(/\/api\/?$/, '');
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Summary
- return relative URL from upload route
- compute full image URL on the client using API base
- expose API base through `window.__API_BASE_URL__`
- display uploaded images correctly across the app

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685377128a248321b71b886958a67c6b