### PR TITLE
Render lap assists

### DIFF
--- a/frontend/src/components/AssistTags.test.tsx
+++ b/frontend/src/components/AssistTags.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import AssistTags from './AssistTags';
+
+test('renders assist names', () => {
+  render(<AssistTags assists={['ABS', 'TCS']} />);
+  expect(screen.getByText('ABS')).toBeInTheDocument();
+  expect(screen.getByText('TCS')).toBeInTheDocument();
+});

--- a/frontend/src/components/AssistTags.tsx
+++ b/frontend/src/components/AssistTags.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface AssistTagsProps {
+  assists?: string[];
+  className?: string;
+}
+
+const AssistTags: React.FC<AssistTagsProps> = ({ assists, className }) => {
+  if (!assists || assists.length === 0) return null;
+  return (
+    <div className={`flex flex-wrap gap-1 ${className || ''}`.trim()}>
+      {assists.map((assist) => (
+        <span
+          key={assist}
+          className="bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs"
+        >
+          {assist}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default AssistTags;

--- a/frontend/src/pages/LapTimesPage.test.tsx
+++ b/frontend/src/pages/LapTimesPage.test.tsx
@@ -1,15 +1,48 @@
 import { render, screen } from '@testing-library/react';
 
-jest.mock('../api', () => ({
-  getLapTimes: () => Promise.resolve([]),
-  getGames: () => Promise.resolve([]),
-  getTracks: () => Promise.resolve([]),
-  getCars: () => Promise.resolve([]),
-}));
+const mockedApi = {
+  getLapTimes: jest.fn(),
+  getGames: jest.fn(),
+  getTracks: jest.fn(),
+  getCars: jest.fn(),
+};
+
+jest.mock('../api', () => mockedApi);
 
 import LapTimesPage from './LapTimesPage';
+
+beforeEach(() => {
+  mockedApi.getLapTimes.mockResolvedValue([]);
+  mockedApi.getGames.mockResolvedValue([]);
+  mockedApi.getTracks.mockResolvedValue([]);
+  mockedApi.getCars.mockResolvedValue([]);
+});
 
 test('renders lap times heading', () => {
   render(<LapTimesPage />);
   expect(screen.getByRole('heading', { name: /Lap Times/i })).toBeInTheDocument();
+});
+
+test('renders assists when provided', async () => {
+  mockedApi.getLapTimes.mockResolvedValueOnce([
+    {
+      id: '1',
+      userId: 'u1',
+      gameId: 'g1',
+      trackId: 't1',
+      layoutId: 'l1',
+      carId: 'c1',
+      inputType: 'Wheel',
+      timeMs: 1234,
+      lapDate: '2023-01-01',
+      username: 'User',
+      gameName: 'Game',
+      trackName: 'Track',
+      carName: 'Car',
+      assists: ['ABS']
+    }
+  ]);
+
+  render(<LapTimesPage />);
+  expect(await screen.findByText('ABS')).toBeInTheDocument();
 });

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -4,6 +4,7 @@ import { getLapTimes, getGames, getTracks, getCars } from '../api';
 import { LapTime, Game, Track, Car } from '../types';
 import { formatTime } from '../utils/time';
 import { getImageUrl } from '../utils';
+import AssistTags from '../components/AssistTags';
 
 const LapTimesPage: React.FC = () => {
   const [view, setView] = useState<'all' | 'filter'>('all');
@@ -94,6 +95,7 @@ const LapTimesPage: React.FC = () => {
                   />
                 )}
                 {l.carName}
+                <AssistTags assists={l.assists} className="mt-1" />
               </td>
               <td className="px-2 py-1 text-right">{formatTime(l.timeMs)}</td>
             </tr>


### PR DESCRIPTION
## Summary
- add `<AssistTags>` component for displaying assists as badges
- show assists under the car column on the lap times table
- test assists are rendered in component and page

## Testing
- `npm test` in backend
- `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6853d238e6948321ada1485eaa5b07f1