### PR TITLE
Add track detail page with leaderboard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import ProfilePage from './pages/ProfilePage';
 import LapTimesPage from './pages/LapTimesPage';
 import SubmitLapTimePage from './pages/SubmitLapTimePage';
 import AdminPage from './pages/AdminPage';
+import TrackDetailPage from './pages/TrackDetailPage';
 import './App.css';
 // Create a client for React Query
 const queryClient = new QueryClient({
@@ -44,6 +45,7 @@ function App() {
                 <Route path="/" element={<Layout />}>
                   <Route index element={<HomePage />} />
                   <Route path="/lap-times" element={<LapTimesPage />} />
+                  <Route path="/track/:id" element={<TrackDetailPage />} />
                   <Route 
                     path="/submit" 
                     element={

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 
 const mockedApi = {
@@ -24,14 +25,22 @@ beforeEach(() => {
 });
 
 test('renders admin heading', () => {
-  render(<AdminPage />);
+  render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>
+  );
   expect(screen.getByText(/Admin/i)).toBeInTheDocument();
 });
 
 test('verifies a lap time', async () => {
   mockedApi.getUnverifiedLapTimes.mockResolvedValue([{ id: '1', timeMs: 123 }]);
   mockedApi.verifyLapTime.mockResolvedValue({ id: '1', verified: true });
-  render(<AdminPage />);
+  render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>
+  );
   expect(await screen.findByText('1')).toBeInTheDocument();
   await userEvent.click(screen.getByRole('button', { name: /verify/i }));
   expect(mockedApi.verifyLapTime).toHaveBeenCalledWith('1');
@@ -40,7 +49,11 @@ test('verifies a lap time', async () => {
 test('deletes a lap time', async () => {
   mockedApi.getUnverifiedLapTimes.mockResolvedValue([{ id: '2', timeMs: 456 }]);
   mockedApi.deleteLapTime.mockResolvedValue({ id: '2' });
-  render(<AdminPage />);
+  render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>
+  );
   expect(await screen.findByText('2')).toBeInTheDocument();
   await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
   expect(mockedApi.deleteLapTime).toHaveBeenCalledWith('2');

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Settings } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import {
   getUnverifiedLapTimes,
   verifyLapTime,
@@ -267,7 +268,9 @@ const AdminPage: React.FC = () => {
                 <td className="p-2">{lt.username}</td>
                 <td className="p-2">{lt.gameName}</td>
                 <td className="p-2">
-                  {lt.trackName}
+                  <Link to={`/track/${lt.trackId}`} className="underline">
+                    {lt.trackName}
+                  </Link>
                   {lt.layoutName ? ` - ${lt.layoutName}` : ''}
                 </td>
                 <td className="p-2">{lt.carName}</td>

--- a/frontend/src/pages/LapTimesPage.test.tsx
+++ b/frontend/src/pages/LapTimesPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockedApi = {
   getLapTimes: jest.fn(),
@@ -19,7 +20,11 @@ beforeEach(() => {
 });
 
 test('renders lap times heading', () => {
-  render(<LapTimesPage />);
+  render(
+    <MemoryRouter>
+      <LapTimesPage />
+    </MemoryRouter>
+  );
   expect(screen.getByRole('heading', { name: /Lap Times/i })).toBeInTheDocument();
 });
 
@@ -43,6 +48,10 @@ test('renders assists when provided', async () => {
     }
   ]);
 
-  render(<LapTimesPage />);
+  render(
+    <MemoryRouter>
+      <LapTimesPage />
+    </MemoryRouter>
+  );
   expect(await screen.findByText('ABS')).toBeInTheDocument();
 });

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Timer } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { getLapTimes, getGames, getTracks, getCars } from '../api';
 import { LapTime, Game, Track, Car } from '../types';
 import { formatTime } from '../utils/time';
@@ -83,7 +84,9 @@ const LapTimesPage: React.FC = () => {
                     className="h-8 w-14 object-cover rounded mb-1"
                   />
                 )}
-                {l.trackName}
+                <Link to={`/track/${l.trackId}`} className="underline">
+                  {l.trackName}
+                </Link>
                 {l.layoutName ? ` - ${l.layoutName}` : ''}
               </td>
               <td className="px-2 py-1">

--- a/frontend/src/pages/TrackDetailPage.test.tsx
+++ b/frontend/src/pages/TrackDetailPage.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+
+const mockedApi = {
+  getTracks: jest.fn(),
+  getLayouts: jest.fn(),
+  getLeaderboard: jest.fn(),
+};
+
+jest.mock('../api', () => mockedApi);
+
+import TrackDetailPage from './TrackDetailPage';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+describe('TrackDetailPage', () => {
+  beforeEach(() => {
+    mockedApi.getTracks.mockResolvedValue([{ id: 't1', gameId: 'g1', name: 'Track', imageUrl: '' }]);
+    mockedApi.getLayouts.mockResolvedValue([]);
+    mockedApi.getLeaderboard.mockResolvedValue([]);
+  });
+
+  it('renders track name', async () => {
+    render(
+      <MemoryRouter initialEntries={["/track/t1"]}>
+        <Routes>
+          <Route path="/track/:id" element={<TrackDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('heading', { name: 'Track' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/TrackDetailPage.tsx
+++ b/frontend/src/pages/TrackDetailPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getTracks, getLayouts, getLeaderboard } from '../api';
+import { Track, Layout, LapTime } from '../types';
+import { getImageUrl } from '../utils';
+import { formatTime } from '../utils/time';
+
+interface LayoutWithTL extends Layout {
+  trackLayoutId?: string;
+}
+
+const TrackDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [track, setTrack] = useState<Track | null>(null);
+  const [layouts, setLayouts] = useState<LayoutWithTL[]>([]);
+  const [records, setRecords] = useState<Record<string, LapTime[]>>({});
+
+  useEffect(() => {
+    if (!id) return;
+    getTracks()
+      .then((data) => {
+        const t = data.find((tr) => tr.id === id) || null;
+        setTrack(t || null);
+      })
+      .catch(() => {});
+  }, [id]);
+
+  useEffect(() => {
+    if (!track) return;
+    getLayouts(track.id)
+      .then((data) => setLayouts(data as LayoutWithTL[]))
+      .catch(() => {});
+  }, [track]);
+
+  useEffect(() => {
+    if (!track) return;
+    layouts.forEach((l) => {
+      if (!l.trackLayoutId) return;
+      getLeaderboard({ gameId: track.gameId, trackLayoutId: l.trackLayoutId })
+        .then((res) =>
+          setRecords((r) => ({ ...r, [l.id]: res }))
+        )
+        .catch(() => {});
+    });
+  }, [track, layouts]);
+
+  if (!track) {
+    return (
+      <div className="container mx-auto py-6 text-center">
+        <p className="text-muted-foreground">Track not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-bold">{track.name}</h1>
+        {track.imageUrl && (
+          <img
+            src={getImageUrl(track.imageUrl)}
+            alt={track.name}
+            className="mx-auto max-w-lg rounded"
+          />
+        )}
+      </div>
+      {layouts.map((layout) => (
+        <div key={layout.id} className="space-y-2">
+          <h2 className="text-2xl font-semibold">{layout.name}</h2>
+          {layout.imageUrl && (
+            <img
+              src={getImageUrl(layout.imageUrl)}
+              alt={layout.name}
+              className="max-w-lg rounded mb-2"
+            />
+          )}
+          {records[layout.id] && records[layout.id].length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm border">
+                <thead>
+                  <tr className="border-b">
+                    <th className="px-2 py-1 text-left">Driver</th>
+                    <th className="px-2 py-1 text-left">Car</th>
+                    <th className="px-2 py-1 text-right">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {records[layout.id].map((r) => (
+                    <tr key={r.id} className="border-b last:border-0">
+                      <td className="px-2 py-1">{r.username}</td>
+                      <td className="px-2 py-1">{r.carName}</td>
+                      <td className="px-2 py-1 text-right">{formatTime(r.timeMs)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">No records yet.</p>
+          )}
+        </div>
+      ))}
+      <div>
+        <Link to="/lap-times" className="text-primary underline">
+          View all lap times
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default TrackDetailPage;
+


### PR DESCRIPTION
## Summary
- add `TrackDetailPage` to view layouts and records
- link track names in lap times and admin pages
- route `/track/:id` in `App.tsx`
- update tests for new links and page

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6853d9af7f7c83218700aa4e36772b78