### PR TITLE
Add validation middleware to game-related routes

### DIFF
--- a/backend/routes/cars.js
+++ b/backend/routes/cars.js
@@ -2,6 +2,7 @@ const express = require('express');
 const db = require('../utils/database');
 const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
+const { body, validationResult } = require('express-validator');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -31,40 +32,68 @@ router.get('/', async (req, res, next) => {
   }
 });
 
-router.post('/', auth, admin, async (req, res, next) => {
-  const { gameId, name, imageUrl } = req.body;
-  try {
-    const car = await db.query(
-      'INSERT INTO cars (name, image_url) VALUES ($1,$2) RETURNING id, name, image_url AS "imageUrl"',
-      [name, imageUrl || null]
-    );
-    const c = car.rows[0];
-    await db.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [gameId, c.id]);
-    res.status(201).json({ id: c.id, gameId, name: c.name, imageUrl: c.imageUrl });
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/:id', auth, admin, async (req, res, next) => {
-  const { id } = req.params;
-  const { gameId, name, imageUrl } = req.body;
-  try {
-    const result = await db.query(
-      'UPDATE cars SET name=$1, image_url=$2 WHERE id=$3 RETURNING id, name, image_url AS "imageUrl"',
-      [name, imageUrl || null, id]
-    );
-    if (result.rows.length === 0) {
-      return res.status(404).json({ message: 'Car not found' });
+router.post(
+  '/',
+  auth,
+  admin,
+  [
+    body('gameId').notEmpty(),
+    body('name').trim().escape().notEmpty(),
+    body('imageUrl').optional().trim(),
+  ],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
-    await db.query('DELETE FROM game_cars WHERE car_id=$1', [id]);
-    await db.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [gameId, id]);
-    const car = result.rows[0];
-    res.json({ id, gameId, name: car.name, imageUrl: car.imageUrl });
-  } catch (err) {
-    next(err);
+    const { gameId, name, imageUrl } = req.body;
+    try {
+      const car = await db.query(
+        'INSERT INTO cars (name, image_url) VALUES ($1,$2) RETURNING id, name, image_url AS "imageUrl"',
+        [name, imageUrl || null]
+      );
+      const c = car.rows[0];
+      await db.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [gameId, c.id]);
+      res.status(201).json({ id: c.id, gameId, name: c.name, imageUrl: c.imageUrl });
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
+
+router.put(
+  '/:id',
+  auth,
+  admin,
+  [
+    body('gameId').notEmpty(),
+    body('name').trim().escape().notEmpty(),
+    body('imageUrl').optional().trim(),
+  ],
+  async (req, res, next) => {
+    const { id } = req.params;
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { gameId, name, imageUrl } = req.body;
+    try {
+      const result = await db.query(
+        'UPDATE cars SET name=$1, image_url=$2 WHERE id=$3 RETURNING id, name, image_url AS "imageUrl"',
+        [name, imageUrl || null, id]
+      );
+      if (result.rows.length === 0) {
+        return res.status(404).json({ message: 'Car not found' });
+      }
+      await db.query('DELETE FROM game_cars WHERE car_id=$1', [id]);
+      await db.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [gameId, id]);
+      const car = result.rows[0];
+      res.json({ id, gameId, name: car.name, imageUrl: car.imageUrl });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
 
 router.delete('/:id', auth, admin, async (req, res, next) => {
   const { id } = req.params;

--- a/backend/routes/games.js
+++ b/backend/routes/games.js
@@ -2,6 +2,7 @@ const express = require('express');
 const db = require('../utils/database');
 const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
+const { body, validationResult } = require('express-validator');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -15,35 +16,55 @@ router.get('/', async (req, res, next) => {
   }
 });
 
-router.post('/', auth, admin, async (req, res, next) => {
-  const { name, imageUrl } = req.body;
-  try {
-    const result = await db.query(
-      'INSERT INTO games (name, image_url) VALUES ($1,$2) RETURNING id, name, image_url AS "imageUrl"',
-      [name, imageUrl || null]
-    );
-    res.status(201).json(result.rows[0]);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/:id', auth, admin, async (req, res, next) => {
-  const { id } = req.params;
-  const { name, imageUrl } = req.body;
-  try {
-    const result = await db.query(
-      'UPDATE games SET name=$1, image_url=$2 WHERE id=$3 RETURNING id, name, image_url AS "imageUrl"',
-      [name, imageUrl || null, id]
-    );
-    if (result.rows.length === 0) {
-      return res.status(404).json({ message: 'Game not found' });
+router.post(
+  '/',
+  auth,
+  admin,
+  [body('name').trim().escape().notEmpty(), body('imageUrl').optional().trim()],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
-    res.json(result.rows[0]);
-  } catch (err) {
-    next(err);
+    const { name, imageUrl } = req.body;
+    try {
+      const result = await db.query(
+        'INSERT INTO games (name, image_url) VALUES ($1,$2) RETURNING id, name, image_url AS "imageUrl"',
+        [name, imageUrl || null]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
+
+router.put(
+  '/:id',
+  auth,
+  admin,
+  [body('name').trim().escape().notEmpty(), body('imageUrl').optional().trim()],
+  async (req, res, next) => {
+    const { id } = req.params;
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { name, imageUrl } = req.body;
+    try {
+      const result = await db.query(
+        'UPDATE games SET name=$1, image_url=$2 WHERE id=$3 RETURNING id, name, image_url AS "imageUrl"',
+        [name, imageUrl || null, id]
+      );
+      if (result.rows.length === 0) {
+        return res.status(404).json({ message: 'Game not found' });
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
 
 router.delete('/:id', auth, admin, async (req, res, next) => {
   const { id } = req.params;

--- a/backend/routes/tracks.js
+++ b/backend/routes/tracks.js
@@ -2,6 +2,7 @@ const express = require('express');
 const db = require('../utils/database');
 const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
+const { body, validationResult } = require('express-validator');
 const router = express.Router();
 
 router.get('/', async (req, res, next) => {
@@ -24,35 +25,63 @@ router.get('/', async (req, res, next) => {
   }
 });
 
-router.post('/', auth, admin, async (req, res, next) => {
-  const { gameId, name, imageUrl } = req.body;
-  try {
-    const result = await db.query(
-      'INSERT INTO tracks (game_id, name, image_url) VALUES ($1,$2,$3) RETURNING id, game_id AS "gameId", name, image_url AS "imageUrl"',
-      [gameId, name, imageUrl || null]
-    );
-    res.status(201).json(result.rows[0]);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/:id', auth, admin, async (req, res, next) => {
-  const { id } = req.params;
-  const { gameId, name, imageUrl } = req.body;
-  try {
-    const result = await db.query(
-      'UPDATE tracks SET game_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING id, game_id AS "gameId", name, image_url AS "imageUrl"',
-      [gameId, name, imageUrl || null, id]
-    );
-    if (result.rows.length === 0) {
-      return res.status(404).json({ message: 'Track not found' });
+router.post(
+  '/',
+  auth,
+  admin,
+  [
+    body('gameId').notEmpty(),
+    body('name').trim().escape().notEmpty(),
+    body('imageUrl').optional().trim(),
+  ],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
     }
-    res.json(result.rows[0]);
-  } catch (err) {
-    next(err);
+    const { gameId, name, imageUrl } = req.body;
+    try {
+      const result = await db.query(
+        'INSERT INTO tracks (game_id, name, image_url) VALUES ($1,$2,$3) RETURNING id, game_id AS "gameId", name, image_url AS "imageUrl"',
+        [gameId, name, imageUrl || null]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
   }
-});
+);
+
+router.put(
+  '/:id',
+  auth,
+  admin,
+  [
+    body('gameId').notEmpty(),
+    body('name').trim().escape().notEmpty(),
+    body('imageUrl').optional().trim(),
+  ],
+  async (req, res, next) => {
+    const { id } = req.params;
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { gameId, name, imageUrl } = req.body;
+    try {
+      const result = await db.query(
+        'UPDATE tracks SET game_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING id, game_id AS "gameId", name, image_url AS "imageUrl"',
+        [gameId, name, imageUrl || null, id]
+      );
+      if (result.rows.length === 0) {
+        return res.status(404).json({ message: 'Track not found' });
+      }
+      res.json(result.rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
 
 router.delete('/:id', auth, admin, async (req, res, next) => {
   const { id } = req.params;


### PR DESCRIPTION
## Summary
- validate POST and PUT requests for games, tracks, layouts and cars
- require names and related IDs, sanitize string input

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6853e0775db083218653a66491c6b3f4