### PR TITLE
Adjust car import mapping

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -161,9 +161,11 @@ router.post('/import', auth, admin, async (req, res, next) => {
       for (const c of cars) {
         // eslint-disable-next-line no-await-in-loop
         await client.query(
-          'INSERT INTO cars (id, game_id, name, image_url, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6)',
-          [c.id, c.game_id, c.name, c.image_url, c.created_at, c.updated_at]
+          'INSERT INTO cars (id, name, image_url, created_at, updated_at) VALUES ($1,$2,$3,$4,$5)',
+          [c.id, c.name, c.image_url, c.created_at, c.updated_at]
         );
+        // eslint-disable-next-line no-await-in-loop
+        await client.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [c.game_id, c.id]);
       }
     }
     if (assists) {

--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -97,13 +97,30 @@ describe('Admin routes', () => {
         games: [],
         tracks: [],
         layouts: [],
-        cars: [],
+        cars: [
+          {
+            id: 'c1',
+            game_id: 'g1',
+            name: 'Car 1',
+            image_url: '/img.png',
+            created_at: '2024-01-01',
+            updated_at: '2024-01-02',
+          },
+        ],
         lap_times: [],
       });
 
     expect(res.status).toBe(200);
     expect(db.pool.connect).toHaveBeenCalled();
     expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO cars (id, name, image_url, created_at, updated_at) VALUES ($1,$2,$3,$4,$5)',
+      ['c1', 'Car 1', '/img.png', '2024-01-01', '2024-01-02']
+    );
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)',
+      ['g1', 'c1']
+    );
     expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
     expect(mockClient.release).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- update the import route to insert into `game_cars`
- adjust admin route unit test to check both inserts

## Testing
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6853e849839883219986032378827ea1