### PR TITLE
Add export/import support for mapping tables

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -77,7 +77,10 @@ router.get('/export', auth, admin, async (req, res, next) => {
       'games',
       'tracks',
       'layouts',
+      'track_layouts',
+      'game_tracks',
       'cars',
+      'game_cars',
       'assists',
       'lap_times',
       'lap_time_assists',
@@ -100,7 +103,10 @@ router.post('/import', auth, admin, async (req, res, next) => {
     games,
     tracks,
     layouts,
+    track_layouts,
+    game_tracks,
     cars,
+    game_cars,
     assists,
     lap_times,
     lap_time_assists,
@@ -109,7 +115,7 @@ router.post('/import', auth, admin, async (req, res, next) => {
   try {
     await client.query('BEGIN');
     await client.query(
-      'TRUNCATE lap_time_assists, lap_times, assists, cars, layouts, tracks, games, users RESTART IDENTITY CASCADE'
+      'TRUNCATE lap_time_assists, lap_times, assists, game_cars, cars, game_tracks, track_layouts, layouts, tracks, games, users RESTART IDENTITY CASCADE'
     );
 
     if (users) {
@@ -157,6 +163,24 @@ router.post('/import', auth, admin, async (req, res, next) => {
         );
       }
     }
+    if (track_layouts) {
+      for (const tl of track_layouts) {
+        // eslint-disable-next-line no-await-in-loop
+        await client.query(
+          'INSERT INTO track_layouts (id, track_id, layout_id) VALUES ($1,$2,$3)',
+          [tl.id, tl.track_id, tl.layout_id]
+        );
+      }
+    }
+    if (game_tracks) {
+      for (const gt of game_tracks) {
+        // eslint-disable-next-line no-await-in-loop
+        await client.query(
+          'INSERT INTO game_tracks (game_id, track_layout_id) VALUES ($1,$2)',
+          [gt.game_id, gt.track_layout_id]
+        );
+      }
+    }
     if (cars) {
       for (const c of cars) {
         // eslint-disable-next-line no-await-in-loop
@@ -164,8 +188,15 @@ router.post('/import', auth, admin, async (req, res, next) => {
           'INSERT INTO cars (id, name, image_url, created_at, updated_at) VALUES ($1,$2,$3,$4,$5)',
           [c.id, c.name, c.image_url, c.created_at, c.updated_at]
         );
+      }
+    }
+    if (game_cars) {
+      for (const gc of game_cars) {
         // eslint-disable-next-line no-await-in-loop
-        await client.query('INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)', [c.game_id, c.id]);
+        await client.query(
+          'INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)',
+          [gc.game_id, gc.car_id]
+        );
       }
     }
     if (assists) {

--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -81,10 +81,13 @@ describe('Admin routes', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
     const res = await request(app).get('/api/admin/export');
     expect(res.status).toBe(200);
-    expect(db.query).toHaveBeenCalledTimes(8);
+    expect(db.query).toHaveBeenCalledTimes(11);
   });
 
   it('imports the database', async () => {
@@ -97,15 +100,23 @@ describe('Admin routes', () => {
         games: [],
         tracks: [],
         layouts: [],
+        track_layouts: [
+          { id: 'tl1', track_id: 't1', layout_id: 'l1' },
+        ],
+        game_tracks: [
+          { game_id: 'g1', track_layout_id: 'tl1' },
+        ],
         cars: [
           {
             id: 'c1',
-            game_id: 'g1',
             name: 'Car 1',
             image_url: '/img.png',
             created_at: '2024-01-01',
             updated_at: '2024-01-02',
           },
+        ],
+        game_cars: [
+          { game_id: 'g1', car_id: 'c1' },
         ],
         lap_times: [],
       });
@@ -113,6 +124,14 @@ describe('Admin routes', () => {
     expect(res.status).toBe(200);
     expect(db.pool.connect).toHaveBeenCalled();
     expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO track_layouts (id, track_id, layout_id) VALUES ($1,$2,$3)',
+      ['tl1', 't1', 'l1']
+    );
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO game_tracks (game_id, track_layout_id) VALUES ($1,$2)',
+      ['g1', 'tl1']
+    );
     expect(mockClient.query).toHaveBeenCalledWith(
       'INSERT INTO cars (id, name, image_url, created_at, updated_at) VALUES ($1,$2,$3,$4,$5)',
       ['c1', 'Car 1', '/img.png', '2024-01-01', '2024-01-02']
@@ -123,5 +142,43 @@ describe('Admin routes', () => {
     );
     expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
     expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  it('export followed by import preserves mappings', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'g1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 't1', game_id: 'g1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'l1', track_id: 't1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'tl1', track_id: 't1', layout_id: 'l1' }] })
+      .mockResolvedValueOnce({ rows: [{ game_id: 'g1', track_layout_id: 'tl1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'c1' }] })
+      .mockResolvedValueOnce({ rows: [{ game_id: 'g1', car_id: 'c1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const exportRes = await request(app).get('/api/admin/export');
+    expect(exportRes.status).toBe(200);
+
+    db.pool.connect.mockResolvedValue(mockClient);
+    mockClient.query.mockReset();
+    mockClient.query.mockResolvedValue({});
+
+    const res = await request(app).post('/api/admin/import').send(exportRes.body);
+
+    expect(res.status).toBe(200);
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO track_layouts (id, track_id, layout_id) VALUES ($1,$2,$3)',
+      ['tl1', 't1', 'l1']
+    );
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO game_tracks (game_id, track_layout_id) VALUES ($1,$2)',
+      ['g1', 'tl1']
+    );
+    expect(mockClient.query).toHaveBeenCalledWith(
+      'INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2)',
+      ['g1', 'c1']
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extend admin data export/import to handle track_layouts, game_tracks and game_cars
- update truncation order and insertion steps
- adjust tests for new mapping tables and add round‑trip regression test

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6853e943c8308321aab90b683204e742