### PR TITLE
Add inline database editor for admin

### DIFF
--- a/frontend/src/components/admin/EditableTable.tsx
+++ b/frontend/src/components/admin/EditableTable.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+
+export interface Column<T> {
+  key: keyof T;
+  label: string;
+  editable?: boolean;
+}
+
+interface EditableTableProps<T extends { id: string }> {
+  data: T[];
+  columns: Column<T>[];
+  onUpdate: (id: string, changes: Partial<T>) => Promise<void>;
+}
+
+function EditableTable<T extends { id: string }>({ data, columns, onUpdate }: EditableTableProps<T>) {
+  const [editingCell, setEditingCell] = useState<{ id: string; key: keyof T } | null>(null);
+  const [changes, setChanges] = useState<Record<string, Partial<T>>>({});
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const startEdit = (id: string, key: keyof T) => {
+    setEditingCell({ id, key });
+  };
+
+  const finishEdit = (id: string, key: keyof T, value: any) => {
+    setChanges((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], [key]: value },
+    }));
+    setEditingCell(null);
+  };
+
+  const saveRow = async (id: string) => {
+    const rowChanges = changes[id];
+    if (!rowChanges) return;
+    setSavingId(id);
+    setError(null);
+    try {
+      await onUpdate(id, rowChanges);
+      setChanges((prev) => {
+        const newChanges = { ...prev };
+        delete newChanges[id];
+        return newChanges;
+      });
+    } catch (err) {
+      setError('Failed to save');
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+      <table className="w-full text-sm text-left border">
+        <thead>
+          <tr className="border-b">
+            {columns.map((col) => (
+              <th key={String(col.key)} className="p-2">
+                {col.label}
+              </th>
+            ))}
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.id} className="border-b">
+              {columns.map((col) => {
+                const value = (changes[row.id]?.[col.key] as any) ?? row[col.key];
+                const isEditing = editingCell && editingCell.id === row.id && editingCell.key === col.key;
+                return (
+                  <td
+                    key={String(col.key)}
+                    className="p-2"
+                    onDoubleClick={() => col.editable && startEdit(row.id, col.key)}
+                  >
+                    {isEditing ? (
+                      <input
+                        className="border p-1 w-full"
+                        autoFocus
+                        defaultValue={value as any}
+                        onBlur={(e) => finishEdit(row.id, col.key, e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            (e.target as HTMLInputElement).blur();
+                          }
+                        }}
+                      />
+                    ) : (
+                      String(value ?? '')
+                    )}
+                  </td>
+                );
+              })}
+              <td className="p-2 space-x-2">
+                <button
+                  className="text-blue-600 disabled:text-gray-400"
+                  disabled={!changes[row.id] || savingId === row.id}
+                  onClick={() => saveRow(row.id)}
+                >
+                  {savingId === row.id ? 'Saving...' : 'Update'}
+                </button>
+              </td>
+            </tr>
+          ))}
+          {data.length === 0 && (
+            <tr>
+              <td colSpan={columns.length + 1} className="p-2 text-center text-muted-foreground">
+                No entries
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default EditableTable;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -29,6 +29,7 @@ import { LapTime, Game, Track, Layout, Car } from '../types';
 import { Button } from '../components/ui/button';
 import { formatTime } from '../utils/time';
 import { slugify, getImageUrl } from '../utils';
+import EditableTable, { Column } from '../components/admin/EditableTable';
 
 const AdminPage: React.FC = () => {
   const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
@@ -62,6 +63,30 @@ const AdminPage: React.FC = () => {
   const [selectedCar, setSelectedCar] = useState('');
   const [importFile, setImportFile] = useState<File | null>(null);
 
+  const gameColumns: Column<Game>[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'name', label: 'Name', editable: true },
+    { key: 'imageUrl', label: 'Image URL', editable: true },
+  ];
+  const trackColumns: Column<Track>[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'gameId', label: 'Game ID', editable: true },
+    { key: 'name', label: 'Name', editable: true },
+    { key: 'imageUrl', label: 'Image URL', editable: true },
+  ];
+  const layoutColumns: Column<Layout>[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'trackId', label: 'Track ID', editable: true },
+    { key: 'name', label: 'Name', editable: true },
+    { key: 'imageUrl', label: 'Image URL', editable: true },
+  ];
+  const carColumns: Column<Car>[] = [
+    { key: 'id', label: 'ID' },
+    { key: 'gameId', label: 'Game ID', editable: true },
+    { key: 'name', label: 'Name', editable: true },
+    { key: 'imageUrl', label: 'Image URL', editable: true },
+  ];
+
   useEffect(() => {
     getUnverifiedLapTimes().then(setLapTimes).catch(() => {});
     getGames().then(setGames).catch(() => {});
@@ -74,6 +99,23 @@ const AdminPage: React.FC = () => {
   const refreshTracks = () => getTracks().then(setTracks).catch(() => {});
   const refreshLayouts = () => getLayouts().then(setLayouts).catch(() => {});
   const refreshCars = () => getCars().then(setCars).catch(() => {});
+
+  const updateGameRow = async (id: string, data: Partial<Game>) => {
+    await updateGame(id, data);
+    refreshGames();
+  };
+  const updateTrackRow = async (id: string, data: Partial<Track>) => {
+    await updateTrack(id, data);
+    refreshTracks();
+  };
+  const updateLayoutRow = async (id: string, data: Partial<Layout>) => {
+    await updateLayout(id, data);
+    refreshLayouts();
+  };
+  const updateCarRow = async (id: string, data: Partial<Car>) => {
+    await updateCar(id, data);
+    refreshCars();
+  };
 
   const handleSaveGame = async () => {
     let imageUrl: string | undefined;
@@ -295,12 +337,33 @@ const AdminPage: React.FC = () => {
                 </td>
               </tr>
             )}
-          </tbody>
-        </table>
-      </section>
+        </tbody>
+      </table>
+    </section>
 
-      <section className="space-y-6">
-        <div>
+    <section className="space-y-6">
+      <h2 className="text-xl font-semibold mb-2">Database Editor</h2>
+      <div>
+        <h3 className="font-semibold mb-2">Games</h3>
+        <EditableTable data={games} columns={gameColumns} onUpdate={updateGameRow} />
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Tracks</h3>
+        <EditableTable data={tracks} columns={trackColumns} onUpdate={updateTrackRow} />
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Layouts</h3>
+        <EditableTable data={layouts} columns={layoutColumns} onUpdate={updateLayoutRow} />
+      </div>
+      <div>
+        <h3 className="font-semibold mb-2">Cars</h3>
+        <EditableTable data={cars} columns={carColumns} onUpdate={updateCarRow} />
+      </div>
+    </section>
+
+    <section className="space-y-6">
+      <h2 className="text-xl font-semibold mb-2">Legacy Editor</h2>
+      <div>
           <h3 className="font-semibold mb-2">Games</h3>
           <div className="flex space-x-2 mb-2">
             <select


### PR DESCRIPTION
## Summary
- add `EditableTable` component for inline editing of database entries
- integrate editable tables into Admin page for games, tracks, layouts, and cars

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853e8fed3548321b1a940f78fdcdca9