### PR TITLE
Remove multipart header from upload API

### DIFF
--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -12,8 +12,6 @@ export async function uploadFile(
   if (filename) params.append('filename', filename);
   const query = params.toString();
   const url = query ? `/uploads?${query}` : '/uploads';
-  const res = await apiClient.post(url, formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
+  const res = await apiClient.post(url, formData);
   return res.data;
 }


### PR DESCRIPTION
## Summary
- let Axios set multipart boundary automatically by dropping explicit content-type header in `uploadFile`

## Testing
- `npm test` within `backend`
- `pnpm test` within `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853efb41bdc8321a045088e9894118a