### PR TITLE
Require auth for uploads and handle errors

### DIFF
--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -1,4 +1,5 @@
 import apiClient from './client';
+import axios from 'axios';
 
 export async function uploadFile(
   file: File,
@@ -12,8 +13,20 @@ export async function uploadFile(
   if (filename) params.append('filename', filename);
   const query = params.toString();
   const url = query ? `/uploads?${query}` : '/uploads';
-  const res = await apiClient.post(url, formData, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return res.data;
+  try {
+    const res = await apiClient.post(url, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return res.data;
+  } catch (err: any) {
+    if (axios.isAxiosError(err) && err.response) {
+      if (err.response.status === 401) {
+        throw new Error('Authentication required to upload files');
+      }
+      if (err.response.status === 403) {
+        throw new Error('You do not have permission to upload files');
+      }
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary
- restrict `/api/uploads` with auth and admin checks
- surface authorization errors on the client when uploading

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853efc9fe7883218fd5431fa101c61a