### PR TITLE
Allow webp uploads

### DIFF
--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -38,7 +38,12 @@ const storage = multer.diskStorage({
     cb(null, name);
   },
 });
-const allowedTypes = ['image/jpeg', 'image/png', 'image/gif'];
+const allowedTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+];
 const upload = multer({
   storage,
   limits: { fileSize: 5 * 1024 * 1024 },


### PR DESCRIPTION
## Summary
- permit more image types, including webp

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853f06b11dc83218b42b3ef3e54325d