### PR TITLE
Fix admin table updates

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -101,19 +101,27 @@ const AdminPage: React.FC = () => {
   const refreshCars = () => getCars().then(setCars).catch(() => {});
 
   const updateGameRow = async (id: string, data: Partial<Game>) => {
-    await updateGame(id, data);
+    const existing = games.find((g) => g.id === id);
+    if (!existing) return;
+    await updateGame(id, { ...existing, ...data });
     refreshGames();
   };
   const updateTrackRow = async (id: string, data: Partial<Track>) => {
-    await updateTrack(id, data);
+    const existing = tracks.find((t) => t.id === id);
+    if (!existing) return;
+    await updateTrack(id, { ...existing, ...data });
     refreshTracks();
   };
   const updateLayoutRow = async (id: string, data: Partial<Layout>) => {
-    await updateLayout(id, data);
+    const existing = layouts.find((l) => l.id === id);
+    if (!existing) return;
+    await updateLayout(id, { ...existing, ...data });
     refreshLayouts();
   };
   const updateCarRow = async (id: string, data: Partial<Car>) => {
-    await updateCar(id, data);
+    const existing = cars.find((c) => c.id === id);
+    if (!existing) return;
+    await updateCar(id, { ...existing, ...data });
     refreshCars();
   };
 


### PR DESCRIPTION
## Summary
- fix admin editable table by sending all fields when updating rows

## Testing
- `pnpm --dir frontend test`
- `pnpm --dir backend test` *(fails: Upload routes test gets 401 instead of 200/400)*

------
https://chatgpt.com/codex/tasks/task_e_6853f7bf03c883218d6f5e006c52508a