### PR TITLE
Add sample lap times and fix upload tests

### DIFF
--- a/backend/tests/uploadRoutes.test.js
+++ b/backend/tests/uploadRoutes.test.js
@@ -3,6 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+jest.mock('../middleware/auth', () => jest.fn((req, res, next) => {
+  req.user = { id: 'user1' };
+  next();
+}));
+
+jest.mock('../middleware/admin', () => jest.fn((req, res, next) => next()));
+
 let app;
 let tmpDir;
 

--- a/database/sample_lap_times.json
+++ b/database/sample_lap_times.json
@@ -1,0 +1,661 @@
+[
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Bahrain",
+    "layout": "Grand Prix",
+    "car": "Mercedes W14",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 148138,
+    "lapDate": "2024-07-17"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Sebring",
+    "layout": "Full Circuit",
+    "car": "Ferrari 488 GT3",
+    "inputType": "Wheel",
+    "assists": [],
+    "timeMs": 104364,
+    "lapDate": "2024-08-17"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Daytona",
+    "layout": "Road Course",
+    "car": "Ferrari 488 GT3",
+    "inputType": "Wheel",
+    "assists": [],
+    "timeMs": 153026,
+    "lapDate": "2024-01-24"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Road America",
+    "layout": "Full Circuit",
+    "car": "Ferrari 488 Challenge Evo",
+    "inputType": "Keyboard",
+    "assists": [
+      "Traction Control",
+      "Braking Indicator",
+      "Stability Control"
+    ],
+    "timeMs": 126339,
+    "lapDate": "2024-08-04"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Silverstone",
+    "layout": "GP Circuit",
+    "car": "Chevrolet Corvette C7.R",
+    "inputType": "Wheel",
+    "assists": [
+      "ABS",
+      "Throttle Assist",
+      "Braking Indicator"
+    ],
+    "timeMs": 121247,
+    "lapDate": "2024-07-10"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Silverstone",
+    "layout": "GP Circuit",
+    "car": "Ford Mustang GT",
+    "inputType": "Controller",
+    "assists": [
+      "Mechanical Failures Off",
+      "Fuel Usage Off",
+      "Automatic Transmission"
+    ],
+    "timeMs": 199569,
+    "lapDate": "2024-12-17"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Sebring",
+    "layout": "Full Circuit",
+    "car": "Acura NSX GT3",
+    "inputType": "Wheel",
+    "assists": [
+      "Traction Control"
+    ],
+    "timeMs": 148686,
+    "lapDate": "2024-07-16"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Monaco",
+    "layout": "Grand Prix",
+    "car": "Ferrari SF-23",
+    "inputType": "Wheel",
+    "assists": [
+      "Launch Control",
+      "Brake Assist",
+      "Racing Line"
+    ],
+    "timeMs": 110248,
+    "lapDate": "2024-12-07"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Monza",
+    "layout": "GP Circuit",
+    "car": "Red Bull RB19",
+    "inputType": "Controller",
+    "assists": [
+      "Suggested Gear Indicator"
+    ],
+    "timeMs": 147664,
+    "lapDate": "2024-01-14"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Hockenheimring",
+    "layout": "GP Circuit",
+    "car": "Corvette C8.R",
+    "inputType": "Wheel",
+    "assists": [
+      "ABS"
+    ],
+    "timeMs": 174719,
+    "lapDate": "2024-02-09"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Monza",
+    "layout": "GP Circuit",
+    "car": "Mercedes AMG GT3",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 152307,
+    "lapDate": "2024-08-01"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Monza",
+    "layout": "Junior Circuit",
+    "car": "Lamborghini Hurac\u00e1n GT3",
+    "inputType": "Wheel",
+    "assists": [
+      "Damage Off",
+      "Tire Wear Off"
+    ],
+    "timeMs": 176265,
+    "lapDate": "2024-01-18"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Brands Hatch",
+    "layout": "GP Circuit",
+    "car": "Nissan GT-R Nismo GT3",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 113223,
+    "lapDate": "2024-06-16"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Monaco",
+    "layout": "Grand Prix",
+    "car": "Acura NSX GT3",
+    "inputType": "Controller",
+    "assists": [
+      "Cornering Guide",
+      "Throttle Assist"
+    ],
+    "timeMs": 109374,
+    "lapDate": "2024-12-12"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Indianapolis",
+    "layout": "Road Course",
+    "car": "Audi R8 LMS",
+    "inputType": "Keyboard",
+    "assists": [
+      "Auto Clutch",
+      "Brake Assist"
+    ],
+    "timeMs": 194182,
+    "lapDate": "2024-03-21"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Silverstone",
+    "layout": "GP Circuit",
+    "car": "Dallara P217",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 180211,
+    "lapDate": "2024-12-21"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Spa-Francorchamps",
+    "layout": "Full Circuit",
+    "car": "Mercedes W14",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 95550,
+    "lapDate": "2024-12-06"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Spa-Francorchamps",
+    "layout": "Full Circuit",
+    "car": "Chevrolet Corvette C7.R",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 101643,
+    "lapDate": "2024-03-09"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Indianapolis",
+    "layout": "Road Course",
+    "car": "Ferrari 488 GT3 Evo",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 81298,
+    "lapDate": "2024-01-01"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Monaco",
+    "layout": "Grand Prix",
+    "car": "BMW M8 GTE",
+    "inputType": "Keyboard",
+    "assists": [
+      "Steering Assist",
+      "Brake Assist"
+    ],
+    "timeMs": 134548,
+    "lapDate": "2024-05-25"
+  },
+  {
+    "user": "racer1",
+    "game": "Forza Motorsport",
+    "track": "Suzuka Circuit",
+    "layout": "East Circuit",
+    "car": "Mazda RX-Vision GT3 Concept",
+    "inputType": "Wheel",
+    "assists": [
+      "Stability Control"
+    ],
+    "timeMs": 127943,
+    "lapDate": "2024-08-09"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Hockenheimring",
+    "layout": "GP Circuit",
+    "car": "Nissan GT-R Nismo GT3",
+    "inputType": "Wheel",
+    "assists": [
+      "Brake Assist",
+      "Auto Clutch"
+    ],
+    "timeMs": 176594,
+    "lapDate": "2024-02-25"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Hockenheimring",
+    "layout": "GP Circuit",
+    "car": "Ford GT GT3",
+    "inputType": "Wheel",
+    "assists": [
+      "Braking Indicator",
+      "Auto Clutch",
+      "Suggested Gear Indicator"
+    ],
+    "timeMs": 123521,
+    "lapDate": "2024-05-09"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Road America",
+    "layout": "Full Circuit",
+    "car": "Mercedes W14",
+    "inputType": "Wheel",
+    "assists": [
+      "Fuel Usage Off"
+    ],
+    "timeMs": 96367,
+    "lapDate": "2024-12-23"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Bahrain",
+    "layout": "Grand Prix",
+    "car": "Lamborghini Hurac\u00e1n GT3",
+    "inputType": "Controller",
+    "assists": [
+      "Cornering Guide",
+      "Fuel Usage Off",
+      "Throttle Assist"
+    ],
+    "timeMs": 165894,
+    "lapDate": "2024-01-19"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Bahrain",
+    "layout": "Grand Prix",
+    "car": "Red Bull RB19",
+    "inputType": "Keyboard",
+    "assists": [
+      "Brake Assist"
+    ],
+    "timeMs": 190370,
+    "lapDate": "2024-02-06"
+  },
+  {
+    "user": "racer1",
+    "game": "Forza Motorsport",
+    "track": "Laguna Seca",
+    "layout": "Full Circuit",
+    "car": "BMW M4 GT3",
+    "inputType": "Wheel",
+    "assists": [
+      "Braking Indicator"
+    ],
+    "timeMs": 185665,
+    "lapDate": "2024-04-08"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Hockenheimring",
+    "layout": "GP Circuit",
+    "car": "Formula RSS 2 V6",
+    "inputType": "Controller",
+    "assists": [],
+    "timeMs": 126936,
+    "lapDate": "2024-03-09"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Sebring",
+    "layout": "Full Circuit",
+    "car": "Ford Mustang GT",
+    "inputType": "Wheel",
+    "assists": [
+      "Ghosting / Collision Off",
+      "Racing Line",
+      "Damage Off"
+    ],
+    "timeMs": 69673,
+    "lapDate": "2024-04-15"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa Competizione",
+    "track": "Monza",
+    "layout": "GP Circuit",
+    "car": "Mazda RX-Vision GT3 Concept",
+    "inputType": "Wheel",
+    "assists": [
+      "Braking Indicator",
+      "Tire Wear Off",
+      "Cornering Guide"
+    ],
+    "timeMs": 147266,
+    "lapDate": "2024-02-10"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Monza",
+    "layout": "Junior Circuit",
+    "car": "Formula RSS 2 V6",
+    "inputType": "Wheel",
+    "assists": [
+      "Throttle Assist"
+    ],
+    "timeMs": 145236,
+    "lapDate": "2024-04-04"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Brands Hatch",
+    "layout": "Indy Circuit",
+    "car": "BMW M4 GT3",
+    "inputType": "Keyboard",
+    "assists": [
+      "Damage Off",
+      "Traction Control"
+    ],
+    "timeMs": 197388,
+    "lapDate": "2024-09-27"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Brands Hatch",
+    "layout": "GP Circuit",
+    "car": "Oreca 07",
+    "inputType": "Keyboard",
+    "assists": [
+      "Cornering Guide",
+      "ABS",
+      "Launch Control"
+    ],
+    "timeMs": 105034,
+    "lapDate": "2024-01-14"
+  },
+  {
+    "user": "racer1",
+    "game": "Forza Motorsport",
+    "track": "Suzuka Circuit",
+    "layout": "GP Circuit",
+    "car": "Ferrari 488 GT3",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 168267,
+    "lapDate": "2024-07-11"
+  },
+  {
+    "user": "racer1",
+    "game": "Gran Turismo 7",
+    "track": "Tokyo Expressway",
+    "layout": "Central Outer Loop",
+    "car": "Ferrari 488 Challenge Evo",
+    "inputType": "Controller",
+    "assists": [
+      "Throttle Assist",
+      "Fuel Usage Off",
+      "Mechanical Failures Off"
+    ],
+    "timeMs": 115295,
+    "lapDate": "2024-10-04"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Road America",
+    "layout": "Full Circuit",
+    "car": "Ferrari 488 GT3",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 186506,
+    "lapDate": "2024-12-02"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Spa-Francorchamps",
+    "layout": "Full Circuit",
+    "car": "McLaren 720S GT3",
+    "inputType": "Keyboard",
+    "assists": [
+      "Racing Line",
+      "Automatic Transmission"
+    ],
+    "timeMs": 61723,
+    "lapDate": "2024-12-14"
+  },
+  {
+    "user": "racer1",
+    "game": "Forza Motorsport",
+    "track": "Suzuka Circuit",
+    "layout": "GP Circuit",
+    "car": "Ferrari 488 GT3 Evo",
+    "inputType": "Wheel",
+    "assists": [
+      "Fuel Usage Off"
+    ],
+    "timeMs": 170752,
+    "lapDate": "2024-06-01"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "Brands Hatch",
+    "layout": "GP Circuit",
+    "car": "Mercedes AMG GT3",
+    "inputType": "Keyboard",
+    "assists": [
+      "Ghosting / Collision Off",
+      "Steering Assist",
+      "Mechanical Failures Off"
+    ],
+    "timeMs": 82105,
+    "lapDate": "2024-09-23"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Imola",
+    "layout": "GP Circuit",
+    "car": "Corvette C8.R",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 160227,
+    "lapDate": "2024-11-08"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Daytona",
+    "layout": "Road Course",
+    "car": "Red Bull RB19",
+    "inputType": "Keyboard",
+    "assists": [
+      "Auto Clutch",
+      "Tire Wear Off"
+    ],
+    "timeMs": 160185,
+    "lapDate": "2024-12-21"
+  },
+  {
+    "user": "racer1",
+    "game": "Project CARS 3",
+    "track": "Imola",
+    "layout": "GP Circuit",
+    "car": "BMW M4 GT3",
+    "inputType": "Controller",
+    "assists": [
+      "Auto Clutch"
+    ],
+    "timeMs": 104069,
+    "lapDate": "2024-09-24"
+  },
+  {
+    "user": "racer1",
+    "game": "Forza Motorsport",
+    "track": "Laguna Seca",
+    "layout": "Full Circuit",
+    "car": "Porsche 911 GT3 Cup",
+    "inputType": "Keyboard",
+    "assists": [],
+    "timeMs": 132083,
+    "lapDate": "2024-05-27"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Daytona",
+    "layout": "Road Course",
+    "car": "Oreca 07",
+    "inputType": "Keyboard",
+    "assists": [
+      "Fuel Usage Off"
+    ],
+    "timeMs": 79780,
+    "lapDate": "2024-05-22"
+  },
+  {
+    "user": "racer1",
+    "game": "Assetto Corsa",
+    "track": "N\u00fcrburgring",
+    "layout": "GP Circuit",
+    "car": "McLaren MP4-12C GT3",
+    "inputType": "Controller",
+    "assists": [
+      "Automatic Transmission"
+    ],
+    "timeMs": 100010,
+    "lapDate": "2024-07-12"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Sebring",
+    "layout": "Full Circuit",
+    "car": "BMW M8 GTE",
+    "inputType": "Keyboard",
+    "assists": [
+      "Mechanical Failures Off",
+      "Auto Clutch",
+      "Braking Indicator"
+    ],
+    "timeMs": 115069,
+    "lapDate": "2024-09-21"
+  },
+  {
+    "user": "racer1",
+    "game": "F1 23",
+    "track": "Monaco",
+    "layout": "Grand Prix",
+    "car": "Chevrolet Corvette C7.R",
+    "inputType": "Controller",
+    "assists": [
+      "Steering Assist",
+      "Racing Line"
+    ],
+    "timeMs": 108704,
+    "lapDate": "2024-04-11"
+  },
+  {
+    "user": "racer1",
+    "game": "iRacing",
+    "track": "Daytona",
+    "layout": "Road Course",
+    "car": "Ford GT GT3",
+    "inputType": "Keyboard",
+    "assists": [
+      "Auto Clutch",
+      "Suggested Gear Indicator"
+    ],
+    "timeMs": 64818,
+    "lapDate": "2024-06-12"
+  },
+  {
+    "user": "racer1",
+    "game": "rFactor 2",
+    "track": "Sebring",
+    "layout": "Full Circuit",
+    "car": "Mazda RX-Vision GT3 Concept",
+    "inputType": "Wheel",
+    "assists": [
+      "Automatic Transmission",
+      "ABS",
+      "Tire Wear Off"
+    ],
+    "timeMs": 178886,
+    "lapDate": "2024-04-05"
+  },
+  {
+    "user": "racer1",
+    "game": "Gran Turismo 7",
+    "track": "Mount Panorama",
+    "layout": "Full Circuit",
+    "car": "Ferrari 488 Challenge Evo",
+    "inputType": "Keyboard",
+    "assists": [
+      "Throttle Assist",
+      "Damage Off"
+    ],
+    "timeMs": 111461,
+    "lapDate": "2024-05-08"
+  }
+]


### PR DESCRIPTION
## Summary
- mock auth in `uploadRoutes.test.js` so tests pass
- generate 50 example lap time records and save to `database/sample_lap_times.json`

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6853fbabb46c8321b715c5d5cbae83ad