### PR TITLE
Add Input Type badges

### DIFF
--- a/backend/tests/uploadRoutes.test.js
+++ b/backend/tests/uploadRoutes.test.js
@@ -3,6 +3,13 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+jest.mock('../middleware/auth', () =>
+  jest.fn((req, res, next) => {
+    req.user = { id: 'user1' };
+    next();
+  })
+);
+
 let app;
 let tmpDir;
 

--- a/frontend/src/components/InputTypeBadge.test.tsx
+++ b/frontend/src/components/InputTypeBadge.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import InputTypeBadge from './InputTypeBadge';
+
+test('renders input type with emoji', () => {
+  render(<InputTypeBadge inputType="Wheel" />);
+  expect(screen.getByText(/Wheel/)).toBeInTheDocument();
+});

--- a/frontend/src/components/InputTypeBadge.tsx
+++ b/frontend/src/components/InputTypeBadge.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface InputTypeBadgeProps {
+  inputType?: string;
+  className?: string;
+}
+
+const icons: Record<string, string> = {
+  Wheel: '🛞',
+  Controller: '🎮',
+  Keyboard: '⌨️',
+};
+
+const InputTypeBadge: React.FC<InputTypeBadgeProps> = ({ inputType, className }) => {
+  if (!inputType) return null;
+  return (
+    <span
+      className={`bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs inline-flex items-center gap-1 ${
+        className || ''
+      }`.trim()}
+    >
+      <span>{icons[inputType] || ''}</span>
+      {inputType}
+    </span>
+  );
+};
+
+export default InputTypeBadge;

--- a/frontend/src/pages/LapTimesPage.test.tsx
+++ b/frontend/src/pages/LapTimesPage.test.tsx
@@ -54,3 +54,30 @@ test('renders assists when provided', async () => {
   );
   expect(await screen.findByText('ABS')).toBeInTheDocument();
 });
+
+test('shows input type badge', async () => {
+  mockedApi.getLapTimes.mockResolvedValueOnce([
+    {
+      id: '1',
+      userId: 'u1',
+      gameId: 'g1',
+      trackLayoutId: 'tl1',
+      carId: 'c1',
+      inputType: 'Controller',
+      timeMs: 1500,
+      lapDate: '2023-01-01',
+      username: 'User',
+      gameName: 'Game',
+      trackName: 'Track',
+      carName: 'Car',
+      assists: []
+    }
+  ]);
+
+  render(
+    <MemoryRouter>
+      <LapTimesPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/Controller/)).toBeInTheDocument();
+});

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -6,6 +6,7 @@ import { LapTime, Game, Track, Car } from '../types';
 import { formatTime } from '../utils/time';
 import { getImageUrl } from '../utils';
 import AssistTags from '../components/AssistTags';
+import InputTypeBadge from '../components/InputTypeBadge';
 
 const LapTimesPage: React.FC = () => {
   const [view, setView] = useState<'all' | 'filter'>('all');
@@ -98,7 +99,10 @@ const LapTimesPage: React.FC = () => {
                   />
                 )}
                 {l.carName}
-                <AssistTags assists={l.assists} className="mt-1" />
+                <div className="mt-1 flex flex-wrap gap-1">
+                  <InputTypeBadge inputType={l.inputType} />
+                  <AssistTags assists={l.assists} />
+                </div>
               </td>
               <td className="px-2 py-1 text-right">{formatTime(l.timeMs)}</td>
             </tr>

--- a/frontend/src/pages/TrackDetailPage.test.tsx
+++ b/frontend/src/pages/TrackDetailPage.test.tsx
@@ -28,4 +28,34 @@ describe('TrackDetailPage', () => {
     );
     expect(await screen.findByRole('heading', { name: 'Track' })).toBeInTheDocument();
   });
+
+  it('shows input type badges in leaderboard', async () => {
+    mockedApi.getLayouts.mockResolvedValueOnce([
+      { id: 'l1', name: 'Layout', trackLayoutId: 'tl1', imageUrl: '' }
+    ]);
+    mockedApi.getLeaderboard.mockResolvedValueOnce([
+      {
+        id: 'lap1',
+        userId: 'u1',
+        gameId: 'g1',
+        trackLayoutId: 'tl1',
+        carId: 'c1',
+        inputType: 'Keyboard',
+        timeMs: 1000,
+        lapDate: '2023-01-01',
+        username: 'User',
+        carName: 'Car'
+      }
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/track/t1"]}>
+        <Routes>
+          <Route path="/track/:id" element={<TrackDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Keyboard/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/TrackDetailPage.tsx
+++ b/frontend/src/pages/TrackDetailPage.tsx
@@ -4,6 +4,7 @@ import { getTracks, getLayouts, getLeaderboard } from '../api';
 import { Track, Layout, LapTime } from '../types';
 import { getImageUrl } from '../utils';
 import { formatTime } from '../utils/time';
+import InputTypeBadge from '../components/InputTypeBadge';
 
 interface LayoutWithTL extends Layout {
   trackLayoutId?: string;
@@ -81,6 +82,7 @@ const TrackDetailPage: React.FC = () => {
                   <tr className="border-b">
                     <th className="px-2 py-1 text-left">Driver</th>
                     <th className="px-2 py-1 text-left">Car</th>
+                    <th className="px-2 py-1 text-left">Input</th>
                     <th className="px-2 py-1 text-right">Time</th>
                   </tr>
                 </thead>
@@ -89,6 +91,9 @@ const TrackDetailPage: React.FC = () => {
                     <tr key={r.id} className="border-b last:border-0">
                       <td className="px-2 py-1">{r.username}</td>
                       <td className="px-2 py-1">{r.carName}</td>
+                      <td className="px-2 py-1">
+                        <InputTypeBadge inputType={r.inputType} />
+                      </td>
                       <td className="px-2 py-1 text-right">{formatTime(r.timeMs)}</td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- show controller/keyboard/wheel icons via new `InputTypeBadge` component
- display input type badges on lap times and track pages
- test new component and update page tests
- mock auth in upload route tests so backend tests pass

## Testing
- `npm test` from `./backend`
- `pnpm test` from `./frontend`


------
https://chatgpt.com/codex/tasks/task_e_6853fd1c6a4c8321a859d89573d00f04