### PR TITLE
Improve import validation and auto seed sample laps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ When the `db` service starts for the first time it runs the SQL files from the
 `database` directory automatically, so the schema and seed data are loaded
 without any manual steps.
 
+On startup the backend checks if the `lap_times` table is empty and, if so,
+loads the records from `database/sample_lap_times.json`. This means the sample
+lap times appear automatically on a fresh installation.
+
 Database data is stored in the `db-data` volume and uploaded files are kept in
 `backend/uploads`.
 
@@ -75,6 +79,10 @@ and executed automatically on the first start. Simply remove the `db-data`
 volume and run `docker compose up -d` again to reset the database.
 
 Adjust connection settings in your backend environment variables as needed.
+
+**Warning**: The Admin page's Import function expects a full database export
+created via the Export button. Uploading any other JSON file will be rejected
+and no data will be modified.
 
 ## Running Tests
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -98,6 +98,9 @@ router.get('/export', auth, admin, async (req, res, next) => {
 });
 
 router.post('/import', auth, admin, async (req, res, next) => {
+  if (!req.body || Array.isArray(req.body) || typeof req.body !== 'object') {
+    return res.status(400).json({ message: 'Invalid import data' });
+  }
   const {
     users,
     games,
@@ -110,6 +113,11 @@ router.post('/import', auth, admin, async (req, res, next) => {
     lap_times,
     lap_time_assists,
   } = req.body;
+
+  const required = [users, games, tracks, layouts, game_tracks, cars, game_cars, assists, lap_times, lap_time_assists];
+  if (required.some((arr) => !Array.isArray(arr))) {
+    return res.status(400).json({ message: 'Invalid import data' });
+  }
   const client = await db.pool.connect();
   try {
     await client.query('BEGIN');

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,7 @@ const leaderboardRoutes = require('./routes/leaderboards');
 const assistRoutes = require('./routes/assists');
 const adminRoutes = require('./routes/admin');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
+const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -58,9 +59,13 @@ app.use(errorHandler);
 const PORT = process.env.PORT || 5000;
 
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
-  });
+  seedSampleLapTimes()
+    .catch((err) => console.error('Failed to seed sample lap times', err))
+    .finally(() => {
+      app.listen(PORT, () => {
+        console.log(`Server running on port ${PORT}`);
+      });
+    });
 }
 
 module.exports = app;

--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -112,6 +112,7 @@ describe('Admin routes', () => {
         game_tracks: [
           { game_id: 'g1', track_layout_id: 'l1' },
         ],
+        assists: [],
         cars: [
           {
             id: 'c1',
@@ -125,6 +126,7 @@ describe('Admin routes', () => {
           { game_id: 'g1', car_id: 'c1' },
         ],
         lap_times: [],
+        lap_time_assists: [],
       });
 
     expect(res.status).toBe(200);
@@ -148,6 +150,14 @@ describe('Admin routes', () => {
     );
     expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
     expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  it('rejects invalid import data', async () => {
+    const res = await request(app)
+      .post('/api/admin/import')
+      .send([{ foo: 'bar' }]);
+    expect(res.status).toBe(400);
+    expect(mockClient.query).not.toHaveBeenCalled();
   });
 
   it('export followed by import preserves mappings', async () => {

--- a/backend/utils/seedSampleLapTimes.js
+++ b/backend/utils/seedSampleLapTimes.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+async function seedSampleLapTimes() {
+  const { rows } = await db.query('SELECT COUNT(*) FROM lap_times');
+  if (parseInt(rows[0].count, 10) > 0) return;
+
+  const file = path.join(__dirname, '..', '..', 'database', 'sample_lap_times.json');
+  let samples;
+  try {
+    samples = JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    console.error('Failed to read sample lap times', err);
+    return;
+  }
+
+  const users = await db.query('SELECT id, username FROM users');
+  const games = await db.query('SELECT id, name FROM games');
+  const trackLayouts = await db.query(`SELECT tl.id, t.name AS track, l.name AS layout
+                                       FROM track_layouts tl
+                                       JOIN tracks t ON tl.track_id = t.id
+                                       JOIN layouts l ON tl.layout_id = l.id`);
+  const cars = await db.query('SELECT id, name FROM cars');
+  const assists = await db.query('SELECT id, name FROM assists');
+
+  const userMap = Object.fromEntries(users.rows.map((u) => [u.username, u.id]));
+  const gameMap = Object.fromEntries(games.rows.map((g) => [g.name, g.id]));
+  const tlMap = Object.fromEntries(trackLayouts.rows.map((r) => [`${r.track}|${r.layout}`, r.id]));
+  const carMap = Object.fromEntries(cars.rows.map((c) => [c.name, c.id]));
+  const assistMap = Object.fromEntries(assists.rows.map((a) => [a.name, a.id]));
+
+  for (const lap of samples) {
+    const userId = userMap[lap.user];
+    const gameId = gameMap[lap.game];
+    const tlId = tlMap[`${lap.track}|${lap.layout}`];
+    const carId = carMap[lap.car];
+    if (!userId || !gameId || !tlId || !carId) continue;
+
+    const res = await db.query(
+      `INSERT INTO lap_times (user_id, game_id, track_layout_id, car_id, input_type, assists_json, time_ms, lap_date)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`,
+      [userId, gameId, tlId, carId, lap.inputType, JSON.stringify(lap.assists), lap.timeMs, lap.lapDate]
+    );
+    const lapId = res.rows[0].id;
+    for (const a of lap.assists) {
+      const aid = assistMap[a];
+      if (aid) {
+        // eslint-disable-next-line no-await-in-loop
+        await db.query('INSERT INTO lap_time_assists (lap_time_id, assist_id) VALUES ($1,$2)', [lapId, aid]);
+      }
+    }
+  }
+  console.log('Inserted sample lap times');
+}
+
+module.exports = { seedSampleLapTimes };


### PR DESCRIPTION
## Summary
- validate import payload to prevent accidental data loss
- auto-populate `lap_times` table with `sample_lap_times.json` on first start
- test the new import validation behavior
- document the automatic seeding and import expectations

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685402a43c908321833499733bb25b46