### PR TITLE
Update docker volume for images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       network: host  # 👈 This enables host networking during image build
     environment:
       VITE_API_URL: http://localhost:5000/api #Change this to your server IP
+    volumes:
+      - ./frontend/public/images:/usr/src/app/dist/images
     depends_on:
       - backend
     ports:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -3,3 +3,5 @@ dist
 build
 tests
 test
+
+public/images


### PR DESCRIPTION
## Summary
- exclude `frontend/public/images` from the frontend Docker build context
- mount `frontend/public/images` into the container so images can be updated without rebuilding

## Testing
- `docker compose build frontend` *(fails: `docker` not found)*
- `docker compose up -d` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549e0d56188321965790b29bf6ea8f