### PR TITLE
Fix access to uploaded images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ pnpm install
 pnpm dev   # starts the Vite dev server
 ```
 
+The development server proxies requests to `/uploads` to the backend so
+uploaded images can be accessed from the same URL as the frontend. Ensure
+`VITE_API_URL` points to your backend instance (for example
+`http://localhost:5000/api`) when running locally or from another device.
+
 Use `pnpm build` to create a production build.
 
 ## Docker Compose

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,26 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiUrl = env.VITE_API_URL || 'http://localhost:5000/api';
+  const backendUrl = apiUrl.replace(/\/api\/?$/, '');
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
     },
-  },
+    server: {
+      proxy: {
+        '/uploads': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- proxy `/uploads` to the backend during development
- document how uploaded images are served

## Testing
- `npm test --prefix backend`
- `pnpm --dir frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6854a16f2ca883218156847b6f443671