### PR TITLE
Ensure sample lap seeding waits for database

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,17 @@ development setup. It starts PostgreSQL, the backend API and the frontend app.
    `db` service used by Docker Compose.
 2. Copy `frontend/.env.production` and set `VITE_API_URL` to the publicly
    reachable URL of the backend, for example `http://localhost:5000/api`.
-3. Run `docker compose build --no-cache frontend` followed by
+3. Ensure the `database` directory is present; Docker Compose mounts it
+   read-only to the backend so the sample lap times can be imported
+   automatically on first startup.
+4. The `db` service includes a healthcheck so the backend waits for PostgreSQL
+   to accept connections before starting.
+5. Run `docker compose build --no-cache frontend` followed by
    `docker compose up -d` from the project root. Building the images requires
    internet access. The `frontend/Dockerfile` runs `npm install -g pnpm`, which
    downloads packages from `registry.npmjs.org`; without a network connection
    this step fails with `EAI_AGAIN`.
-4. Visit `http://localhost:5173` to access the UI. The API will be available at
+6. Visit `http://localhost:5173` to access the UI. The API will be available at
    `http://localhost:5000`.
 
 When the `db` service starts for the first time it runs the SQL files from the

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,7 @@ const assistRoutes = require('./routes/assists');
 const adminRoutes = require('./routes/admin');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
+const waitForDb = require('./utils/waitForDb');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -59,13 +60,17 @@ app.use(errorHandler);
 const PORT = process.env.PORT || 5000;
 
 if (process.env.NODE_ENV !== 'test') {
-  seedSampleLapTimes()
-    .catch((err) => console.error('Failed to seed sample lap times', err))
-    .finally(() => {
-      app.listen(PORT, () => {
-        console.log(`Server running on port ${PORT}`);
-      });
+  (async () => {
+    try {
+      await waitForDb();
+      await seedSampleLapTimes();
+    } catch (err) {
+      console.error('Failed to seed sample lap times', err);
+    }
+    app.listen(PORT, () => {
+      console.log(`Server running on port ${PORT}`);
     });
+  })();
 }
 
 module.exports = app;

--- a/backend/utils/waitForDb.js
+++ b/backend/utils/waitForDb.js
@@ -1,0 +1,16 @@
+const db = require('./database');
+
+async function waitForDb({ retries = 10, delay = 3000 } = {}) {
+  for (let i = 0; i < retries; i += 1) {
+    try {
+      await db.query('SELECT 1');
+      return true;
+    } catch (err) {
+      console.log(`Database not ready (${err.code}); retrying in ${delay / 1000}s...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw new Error('Database never became ready');
+}
+
+module.exports = waitForDb;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - ./database:/docker-entrypoint-initdb.d:ro
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   backend:
     build:
@@ -23,8 +28,10 @@ services:
       UPLOAD_DIR: uploads
     volumes:
       - ./backend/uploads:/usr/src/app/uploads
+      - ./database:/usr/src/database:ro
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "5000:5000"
 


### PR DESCRIPTION
## Summary
- add healthcheck to PostgreSQL container
- wait for DB connection before seeding
- document the healthcheck in Docker instructions

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6854abda7a3c8321ad2e08ec95e84e6d