### PR TITLE
Support image/x-png uploads

### DIFF
--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -43,6 +43,7 @@ const storage = multer.diskStorage({
 const allowedTypes = [
   'image/jpeg',
   'image/png',
+  'image/x-png',
   'image/gif',
   'image/webp',
 ];

--- a/backend/tests/uploadRoutes.test.js
+++ b/backend/tests/uploadRoutes.test.js
@@ -49,6 +49,23 @@ describe('Upload routes', () => {
     expect(fs.existsSync(storedPath)).toBe(true);
   });
 
+  it('accepts legacy x-png mime type', async () => {
+    const pngBuffer = Buffer.from(
+      '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6360000002000100057ff2d80000000049454e44ae426082',
+      'hex'
+    );
+
+    const res = await request(app)
+      .post('/api/uploads')
+      .attach('file', pngBuffer, { filename: 'test.png', contentType: 'image/x-png' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.url).toMatch(/^\/uploads\/.*\.png$/);
+
+    const storedPath = path.join(tmpDir, path.basename(res.body.url));
+    expect(fs.existsSync(storedPath)).toBe(true);
+  });
+
   it('rejects invalid file type', async () => {
     const beforeFiles = fs.readdirSync(tmpDir).length;
 


### PR DESCRIPTION
## Summary
- allow legacy `image/x-png` MIME type when uploading images
- test uploading a PNG using the legacy MIME type

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6854c803c41883218b31e2fe168c26a0