### PR TITLE
Add version display on Admin page

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,5 @@ DATABASE_URL=postgres://postgres:postgres@db:5432/racing
 JWT_SECRET=your_jwt_secret
 PORT=5000
 UPLOAD_DIR=uploads
+APP_VERSION=v0.1
+DB_VERSION=v1

--- a/backend/routes/version.js
+++ b/backend/routes/version.js
@@ -1,0 +1,12 @@
+const express = require('express');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json({
+    appVersion: process.env.APP_VERSION || 'v0.1',
+    dbVersion: process.env.DB_VERSION || 'v1',
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ const lapTimeRoutes = require('./routes/lapTimes');
 const leaderboardRoutes = require('./routes/leaderboards');
 const assistRoutes = require('./routes/assists');
 const adminRoutes = require('./routes/admin');
+const versionRoutes = require('./routes/version');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
 const waitForDb = require('./utils/waitForDb');
@@ -53,6 +54,7 @@ app.use('/api/lapTimes', lapTimeRoutes);
 app.use('/api/leaderboards', leaderboardRoutes);
 app.use('/api/uploads', uploadRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/version', versionRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/backend/tests/versionRoutes.test.js
+++ b/backend/tests/versionRoutes.test.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Version route', () => {
+  it('returns app and db versions', async () => {
+    const res = await request(app).get('/api/version');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('appVersion');
+    expect(res.body).toHaveProperty('dbVersion');
+  });
+});

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -9,3 +9,4 @@ export * from './upload';
 export * from './admin';
 export * from './users';
 export * from './assists';
+export * from './version';

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,0 +1,11 @@
+import apiClient from './client';
+
+export interface VersionInfo {
+  appVersion: string;
+  dbVersion: string;
+}
+
+export async function getVersion(): Promise<VersionInfo> {
+  const res = await apiClient.get('/version');
+  return res.data as VersionInfo;
+}

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -10,6 +10,7 @@ const mockedApi = {
   getCars: jest.fn(),
   verifyLapTime: jest.fn(),
   deleteLapTime: jest.fn(),
+  getVersion: jest.fn(),
 };
 
 jest.mock('../api', () => mockedApi);
@@ -22,6 +23,7 @@ beforeEach(() => {
   mockedApi.getTracks.mockResolvedValue([]);
   mockedApi.getLayouts.mockResolvedValue([]);
   mockedApi.getCars.mockResolvedValue([]);
+  mockedApi.getVersion.mockResolvedValue({ appVersion: 'v0.1', dbVersion: 'v1' });
 });
 
 test('renders admin heading', () => {
@@ -31,6 +33,16 @@ test('renders admin heading', () => {
     </MemoryRouter>
   );
   expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+});
+
+test('shows version information', async () => {
+  render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>
+  );
+  expect(await screen.findByText(/App version/i)).toBeInTheDocument();
+  expect(screen.getByText(/Database version/i)).toBeInTheDocument();
 });
 
 test('verifies a lap time', async () => {

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -24,6 +24,7 @@ import {
   uploadFile,
   exportDatabase,
   importDatabase,
+  getVersion,
 } from '../api';
 import { LapTime, Game, Track, Layout, Car } from '../types';
 import { Button } from '../components/ui/button';
@@ -38,6 +39,8 @@ const AdminPage: React.FC = () => {
   const [tracks, setTracks] = useState<Track[]>([]);
   const [layouts, setLayouts] = useState<Layout[]>([]);
   const [cars, setCars] = useState<Car[]>([]);
+  const [appVersion, setAppVersion] = useState('');
+  const [dbVersion, setDbVersion] = useState('');
 
   const [gameImage, setGameImage] = useState<File | null>(null);
   const [trackImage, setTrackImage] = useState<File | null>(null);
@@ -96,6 +99,12 @@ const AdminPage: React.FC = () => {
     getTracks().then(setTracks).catch(() => {});
     getLayouts().then(setLayouts).catch(() => {});
     getCars().then(setCars).catch(() => {});
+    getVersion()
+      .then((v) => {
+        setAppVersion(v.appVersion);
+        setDbVersion(v.dbVersion);
+      })
+      .catch(() => {});
   }, []);
 
   const refreshGames = () => getGames().then(setGames).catch(() => {});
@@ -612,6 +621,10 @@ const AdminPage: React.FC = () => {
             </Button>
           </div>
         </div>
+      </section>
+      <section className="mt-6 text-sm text-gray-500">
+        <p>App version: {appVersion}</p>
+        <p>Database version: {dbVersion}</p>
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- include `APP_VERSION` and `DB_VERSION` in env example
- expose `/api/version` endpoint
- fetch app/db version in frontend and show on Admin page
- cover new route and UI behaviour with tests

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6854ca1e112483219260c6c88c407ebe