### PR TITLE
Improve admin UI and add user management

### DIFF
--- a/backend/routes/adminUsers.js
+++ b/backend/routes/adminUsers.js
@@ -1,0 +1,116 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const { body, validationResult } = require('express-validator');
+const db = require('../utils/database');
+const auth = require('../middleware/auth');
+const admin = require('../middleware/admin');
+
+const router = express.Router();
+
+router.get('/', auth, admin, async (req, res, next) => {
+  try {
+    const result = await db.query('SELECT id, username, email, is_admin FROM users ORDER BY username');
+    res.json(result.rows.map((u) => ({ id: u.id, username: u.username, email: u.email, isAdmin: u.is_admin })));
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post(
+  '/',
+  auth,
+  admin,
+  [body('username').notEmpty(), body('email').isEmail(), body('password').isLength({ min: 6 }), body('isAdmin').optional().isBoolean()],
+  async (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, email, password, isAdmin } = req.body;
+    try {
+      const hashed = await bcrypt.hash(password, 10);
+      const result = await db.query(
+        'INSERT INTO users (username, email, password_hash, is_admin) VALUES ($1,$2,$3,$4) RETURNING id, username, email, is_admin',
+        [username, email, hashed, isAdmin || false]
+      );
+      const u = result.rows[0];
+      res.status(201).json({ id: u.id, username: u.username, email: u.email, isAdmin: u.is_admin });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.put(
+  '/:id',
+  auth,
+  admin,
+  [body('username').optional().notEmpty(), body('email').optional().isEmail(), body('password').optional().isLength({ min: 6 }), body('isAdmin').optional().isBoolean()],
+  async (req, res, next) => {
+    const { id } = req.params;
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, email, password, isAdmin } = req.body;
+    const fields = [];
+    const params = [];
+    if (username !== undefined) {
+      params.push(username);
+      fields.push(`username = $${params.length}`);
+    }
+    if (email !== undefined) {
+      params.push(email);
+      fields.push(`email = $${params.length}`);
+    }
+    if (typeof isAdmin === 'boolean') {
+      params.push(isAdmin);
+      fields.push(`is_admin = $${params.length}`);
+    }
+    if (password) {
+      const hashed = await bcrypt.hash(password, 10);
+      params.push(hashed);
+      fields.push(`password_hash = $${params.length}`);
+    }
+    if (fields.length === 0) {
+      return res.status(400).json({ message: 'No fields provided' });
+    }
+    params.push(id);
+    try {
+      const result = await db.query(
+        `UPDATE users SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${params.length} RETURNING id, username, email, is_admin`,
+        params
+      );
+      if (result.rows.length === 0) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      const u = result.rows[0];
+      res.json({ id: u.id, username: u.username, email: u.email, isAdmin: u.is_admin });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+router.delete('/:id', auth, admin, async (req, res, next) => {
+  const { id } = req.params;
+  const keepTimes = req.query.keepTimes === 'true' || req.query.keepTimes === '1';
+  try {
+    if (keepTimes) {
+      await db.query(
+        'UPDATE users SET username=$1, email=$2, password_hash=$3, avatar_url=NULL, is_admin=FALSE WHERE id=$4',
+        [`deleted-${Date.now()}`, '', '', id]
+      );
+      return res.json({ id });
+    }
+    const result = await db.query('DELETE FROM users WHERE id=$1 RETURNING id', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ const lapTimeRoutes = require('./routes/lapTimes');
 const leaderboardRoutes = require('./routes/leaderboards');
 const assistRoutes = require('./routes/assists');
 const adminRoutes = require('./routes/admin');
+const adminUserRoutes = require('./routes/adminUsers');
 const versionRoutes = require('./routes/version');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
@@ -54,6 +55,7 @@ app.use('/api/lapTimes', lapTimeRoutes);
 app.use('/api/leaderboards', leaderboardRoutes);
 app.use('/api/uploads', uploadRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/admin/users', adminUserRoutes);
 app.use('/api/version', versionRoutes);
 
 // Error handling

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,5 +1,5 @@
 import apiClient from './client';
-import { LapTime, Game, Track, Layout, Car } from '../types';
+import { LapTime, Game, Track, Layout, Car, User } from '../types';
 
 export async function getUnverifiedLapTimes(): Promise<LapTime[]> {
   const res = await apiClient.get('/admin/lapTimes/unverified');
@@ -93,5 +93,25 @@ export async function importDatabase(
       }
     },
   });
+  return res.data;
+}
+
+export async function getUsers(): Promise<User[]> {
+  const res = await apiClient.get('/admin/users');
+  return res.data;
+}
+
+export async function createUser(data: Partial<User> & { password: string }): Promise<User> {
+  const res = await apiClient.post('/admin/users', data);
+  return res.data;
+}
+
+export async function updateUser(id: string, data: Partial<User> & { password?: string }): Promise<User> {
+  const res = await apiClient.put(`/admin/users/${id}`, data);
+  return res.data;
+}
+
+export async function deleteUser(id: string, keepTimes?: boolean): Promise<any> {
+  const res = await apiClient.delete(`/admin/users/${id}`, { params: { keepTimes } });
   return res.data;
 }

--- a/frontend/src/components/admin/CollapsibleSection.tsx
+++ b/frontend/src/components/admin/CollapsibleSection.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as Collapsible from '@radix-ui/react-collapsible';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '../../utils';
+
+interface Props {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}
+
+const CollapsibleSection: React.FC<Props> = ({ title, defaultOpen = false, children }) => {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen} className="space-y-2">
+      <Collapsible.Trigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-xl font-semibold mb-2"
+        >
+          <span>{title}</span>
+          <ChevronDown className={cn('h-4 w-4 transition-transform', open ? 'rotate-180' : 'rotate-0')} />
+        </button>
+      </Collapsible.Trigger>
+      <Collapsible.Content className="space-y-4">
+        {children}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+};
+
+export default CollapsibleSection;

--- a/frontend/src/components/admin/EditableTable.tsx
+++ b/frontend/src/components/admin/EditableTable.tsx
@@ -10,6 +10,7 @@ interface EditableTableProps<T extends { id: string }> {
   data: T[];
   columns: Column<T>[];
   onUpdate: (id: string, changes: Partial<T>) => Promise<void>;
+  onDelete?: (id: string) => Promise<void> | void;
 }
 
 function EditableTable<T extends { id: string }>({ data, columns, onUpdate }: EditableTableProps<T>) {
@@ -101,6 +102,14 @@ function EditableTable<T extends { id: string }>({ data, columns, onUpdate }: Ed
                 >
                   {savingId === row.id ? 'Saving...' : 'Update'}
                 </button>
+                {onDelete && (
+                  <button
+                    className="text-red-600"
+                    onClick={() => onDelete(row.id)}
+                  >
+                    Delete
+                  </button>
+                )}
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -11,6 +11,10 @@ const mockedApi = {
   verifyLapTime: jest.fn(),
   deleteLapTime: jest.fn(),
   getVersion: jest.fn(),
+  getUsers: jest.fn(),
+  createUser: jest.fn(),
+  updateUser: jest.fn(),
+  deleteUser: jest.fn(),
 };
 
 jest.mock('../api', () => mockedApi);
@@ -23,6 +27,7 @@ beforeEach(() => {
   mockedApi.getTracks.mockResolvedValue([]);
   mockedApi.getLayouts.mockResolvedValue([]);
   mockedApi.getCars.mockResolvedValue([]);
+  mockedApi.getUsers.mockResolvedValue([]);
   mockedApi.getVersion.mockResolvedValue({ appVersion: 'v0.1', dbVersion: 'v1' });
 });
 
@@ -32,7 +37,7 @@ test('renders admin heading', () => {
       <AdminPage />
     </MemoryRouter>
   );
-  expect(screen.getByText(/Admin/i)).toBeInTheDocument();
+  expect(screen.getByRole('heading', { name: /Admin/i })).toBeInTheDocument();
 });
 
 test('shows version information', async () => {
@@ -53,6 +58,7 @@ test('verifies a lap time', async () => {
       <AdminPage />
     </MemoryRouter>
   );
+  await userEvent.click(screen.getByRole('button', { name: /unverified lap times/i }));
   expect(await screen.findByText('1')).toBeInTheDocument();
   await userEvent.click(screen.getByRole('button', { name: /verify/i }));
   expect(mockedApi.verifyLapTime).toHaveBeenCalledWith('1');
@@ -66,6 +72,7 @@ test('deletes a lap time', async () => {
       <AdminPage />
     </MemoryRouter>
   );
+  await userEvent.click(screen.getByRole('button', { name: /unverified lap times/i }));
   expect(await screen.findByText('2')).toBeInTheDocument();
   await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
   expect(mockedApi.deleteLapTime).toHaveBeenCalledWith('2');


### PR DESCRIPTION
## Summary
- add collapsible section component
- collapse unverified laps and DB editor in Admin page
- add user management tools
- expose admin user routes on backend
- extend admin API and table for delete support
- update tests for new layout

## Testing
- `npm --prefix frontend test -- src/pages/AdminPage.test.tsx`
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6855267024148321a49c0eba8a1dc2ac