### PR TITLE
Fix missing onDelete prop in EditableTable

### DIFF
--- a/frontend/src/components/admin/EditableTable.tsx
+++ b/frontend/src/components/admin/EditableTable.tsx
@@ -13,7 +13,7 @@ interface EditableTableProps<T extends { id: string }> {
   onDelete?: (id: string) => Promise<void> | void;
 }
 
-function EditableTable<T extends { id: string }>({ data, columns, onUpdate }: EditableTableProps<T>) {
+function EditableTable<T extends { id: string }>({ data, columns, onUpdate, onDelete }: EditableTableProps<T>) {
   const [editingCell, setEditingCell] = useState<{ id: string; key: keyof T } | null>(null);
   const [changes, setChanges] = useState<Record<string, Partial<T>>>({});
   const [savingId, setSavingId] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- include `onDelete` prop in `EditableTable`'s destructuring

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`
- `pnpm build` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68554200ed1c8321a46748d2c7e502e6