### PR TITLE
Add lap detail popup and comments

### DIFF
--- a/frontend/src/components/LapTimePopup.tsx
+++ b/frontend/src/components/LapTimePopup.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { LapTime } from '../types';
+import { formatTime } from '../utils/time';
+import { getImageUrl } from '../utils';
+import AssistTags from './AssistTags';
+import InputTypeBadge from './InputTypeBadge';
+
+interface LapTimePopupProps {
+  lap: LapTime;
+}
+
+const LapTimePopup: React.FC<LapTimePopupProps> = ({ lap }) => {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-center">Lap Details</h2>
+      {lap.screenshotUrl && (
+        <img
+          src={getImageUrl(lap.screenshotUrl)}
+          alt="Lap screenshot"
+          className="w-full rounded"
+        />
+      )}
+      <table className="w-full text-sm">
+        <tbody>
+          <tr>
+            <td className="font-medium pr-2">Driver:</td>
+            <td>{lap.username}</td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Game:</td>
+            <td>{lap.gameName}</td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Track:</td>
+            <td>
+              {lap.trackName}
+              {lap.layoutName ? ` - ${lap.layoutName}` : ''}
+            </td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Car:</td>
+            <td>{lap.carName}</td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Input:</td>
+            <td>
+              <InputTypeBadge inputType={lap.inputType} />
+            </td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Time:</td>
+            <td>{formatTime(lap.timeMs)}</td>
+          </tr>
+          <tr>
+            <td className="font-medium pr-2">Date:</td>
+            <td>{new Date(lap.lapDate).toLocaleDateString()}</td>
+          </tr>
+        </tbody>
+      </table>
+      <AssistTags assists={lap.assists} />
+      {lap.notes && (
+        <div>
+          <h3 className="text-sm font-semibold mb-1">Comments</h3>
+          <p className="text-sm whitespace-pre-line">{lap.notes}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LapTimePopup;

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,29 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import React from 'react';
+import { cn } from '../../utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/50" />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 w-[90vw] max-w-lg translate-y-[-50%] top-1/2 left-1/2 -translate-x-1/2 bg-background p-4 rounded shadow-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+DialogContent.displayName = 'DialogContent';
+
+export { Dialog, DialogTrigger, DialogClose, DialogContent };

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -7,10 +7,13 @@ import { formatTime } from '../utils/time';
 import { getImageUrl } from '../utils';
 import AssistTags from '../components/AssistTags';
 import InputTypeBadge from '../components/InputTypeBadge';
+import { Dialog, DialogContent } from '../components/ui/dialog';
+import LapTimePopup from '../components/LapTimePopup';
 
 const LapTimesPage: React.FC = () => {
   const [view, setView] = useState<'all' | 'filter'>('all');
   const [laps, setLaps] = useState<LapTime[]>([]);
+  const [selectedLap, setSelectedLap] = useState<LapTime | null>(null);
 
   const [games, setGames] = useState<Game[]>([]);
   const [tracks, setTracks] = useState<Track[]>([]);
@@ -65,7 +68,11 @@ const LapTimesPage: React.FC = () => {
         </thead>
         <tbody>
           {data.map((l) => (
-            <tr key={l.id} className="border-b last:border-0">
+            <tr
+              key={l.id}
+              className="border-b last:border-0 cursor-pointer hover:bg-muted"
+              onClick={() => setSelectedLap(l)}
+            >
               <td className="px-2 py-1">{l.username}</td>
               <td className="px-2 py-1">
                 {l.gameImageUrl && (
@@ -182,6 +189,12 @@ const LapTimesPage: React.FC = () => {
       ) : (
         <p className="text-center text-muted-foreground">No lap times found.</p>
       )}
+
+      <Dialog open={!!selectedLap} onOpenChange={(o) => !o && setSelectedLap(null)}>
+        <DialogContent>
+          {selectedLap && <LapTimePopup lap={selectedLap} />}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/pages/SubmitLapTimePage.test.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.test.tsx
@@ -30,3 +30,8 @@ test('renders assist checkboxes', async () => {
   render(<SubmitLapTimePage />);
   expect(await screen.findByLabelText(/ABS/)).toBeInTheDocument();
 });
+
+test('shows comments textarea', () => {
+  render(<SubmitLapTimePage />);
+  expect(screen.getByLabelText(/Comments/i)).toBeInTheDocument();
+});

--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -54,6 +54,7 @@ const SubmitLapTimePage: React.FC = () => {
   const [time, setTime] = useState('');
   const [lapDate, setLapDate] = useState('');
   const [screenshot, setScreenshot] = useState<File | null>(null);
+  const [notes, setNotes] = useState('');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
@@ -119,6 +120,7 @@ const SubmitLapTimePage: React.FC = () => {
         lapDate,
         screenshotUrl,
         assists: selectedAssists,
+        notes,
       });
       navigate('/lap-times');
     } catch (err: any) {
@@ -246,6 +248,18 @@ const SubmitLapTimePage: React.FC = () => {
                 accept="image/*"
                 onChange={(e) => setScreenshot(e.target.files?.[0] || null)}
                 className="w-full"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="notes" className="block text-sm font-medium">
+                Comments
+              </label>
+              <textarea
+                id="notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                className="w-full rounded border px-3 py-2"
+                rows={3}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add support for comments when submitting lap times
- show lap details in a popup dialog with screenshot and assists
- ensure form label works in tests

## Testing
- `npm test --prefix frontend -- -u --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68554dad4ce88321af2784f313bde1f3