### PR TITLE
Simplify VITE_API_URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Root environment configuration
+# Set the public URL of the backend API. Docker Compose uses this value
+# for building and running the frontend container.
+VITE_API_URL=http://localhost:5000/api

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ development setup. It starts PostgreSQL, the backend API and the frontend app.
 1. Copy `backend/.env.example` to `backend/.env` and adjust the variables if
    needed (especially `JWT_SECRET`). The default `DATABASE_URL` points to the
    `db` service used by Docker Compose.
-2. Copy `frontend/.env.production` and set `VITE_API_URL` to the publicly
+2. Copy `.env.example` to `.env` and set `VITE_API_URL` to the publicly
    reachable URL of the backend, for example `http://localhost:5000/api`.
 3. Ensure the `database` directory is present; Docker Compose mounts it
    read-only to the backend so the sample lap times can be imported
@@ -57,7 +57,8 @@ development setup. It starts PostgreSQL, the backend API and the frontend app.
 4. The `db` service includes a healthcheck so the backend waits for PostgreSQL
    to accept connections before starting.
 5. Run `docker compose build --no-cache frontend` followed by
-   `docker compose up -d` from the project root. Building the images requires
+   `docker compose up -d` from the project root. Docker Compose loads
+   variables from `.env` automatically. Building the images requires
    internet access. The `frontend/Dockerfile` runs `npm install -g pnpm`, which
    downloads packages from `registry.npmjs.org`; without a network connection
    this step fails with `EAI_AGAIN`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,10 @@ services:
     build:
       context: ./frontend
       network: host  # 👈 This enables host networking during image build
+      args:
+        - VITE_API_URL=${VITE_API_URL}
     environment:
-      VITE_API_URL: http://localhost:5000/api #Change this to your server IP
+      VITE_API_URL: ${VITE_API_URL}
     volumes:
       - ./frontend/public/images:/usr/src/app/dist/images
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,10 @@ FROM node:18
 WORKDIR /usr/src/app
 RUN npm install -g pnpm
 COPY pnpm-lock.yaml package.json ./
-COPY .env.production .env
 RUN pnpm install
 COPY . .
-COPY .env.production .env
+ARG VITE_API_URL=http://localhost:5000/api
+RUN echo "VITE_API_URL=$VITE_API_URL" > .env
 RUN pnpm build
 EXPOSE 4173
 CMD ["pnpm", "preview", "--host", "--port", "4173"]


### PR DESCRIPTION
## Summary
- add project-wide `.env.example`
- use `${VITE_API_URL}` in Compose file and pass build arg
- update frontend Dockerfile to read build argument
- document new setup in the README

## Testing
- `npm test` from `backend`
- `pnpm test` from `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68555db1088c8321a186b055e4e5aa27