### PR TITLE
Add profile fields and default assists

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -10,6 +10,15 @@ CREATE TABLE users (
     password_hash VARCHAR(255) NOT NULL,
     is_admin BOOLEAN DEFAULT FALSE,
     avatar_url TEXT,
+    wheel TEXT,
+    frame TEXT,
+    brakes TEXT,
+    equipment TEXT,
+    favorite_sim TEXT,
+    favorite_track TEXT,
+    favorite_car TEXT,
+    default_assists JSONB,
+    league TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -29,6 +29,19 @@ export async function register(
 
 export async function getCurrentUser(): Promise<User> {
   const res = await apiClient.get('/users/me');
-  const { is_admin, avatar_url, ...rest } = res.data;
-  return { ...rest, isAdmin: is_admin, avatarUrl: avatar_url };
+  const { is_admin, avatar_url, default_assists, favorite_sim, favorite_track, favorite_car, wheel, frame, brakes, equipment, league, ...rest } = res.data;
+  return {
+    ...rest,
+    isAdmin: is_admin,
+    avatarUrl: avatar_url,
+    defaultAssists: default_assists || [],
+    favoriteSim: favorite_sim || '',
+    favoriteTrack: favorite_track || '',
+    favoriteCar: favorite_car || '',
+    wheel: wheel || '',
+    frame: frame || '',
+    brakes: brakes || '',
+    equipment: equipment || '',
+    league: league || '',
+  } as User;
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,10 +1,50 @@
 import apiClient from './client';
 import { User, UserStats } from '../types';
 
-export async function updateProfile(data: { username?: string; avatarUrl?: string }): Promise<User> {
+export async function updateProfile(
+  data: {
+    username?: string;
+    avatarUrl?: string;
+    wheel?: string;
+    frame?: string;
+    brakes?: string;
+    equipment?: string;
+    favoriteSim?: string;
+    favoriteTrack?: string;
+    favoriteCar?: string;
+    defaultAssists?: string[];
+    league?: string;
+  }
+): Promise<User> {
   const res = await apiClient.put('/users/me', data);
-  const { is_admin, avatar_url, ...rest } = res.data;
-  return { ...rest, isAdmin: is_admin, avatarUrl: avatar_url };
+  const {
+    is_admin,
+    avatar_url,
+    default_assists,
+    favorite_sim,
+    favorite_track,
+    favorite_car,
+    wheel,
+    frame,
+    brakes,
+    equipment,
+    league,
+    ...rest
+  } = res.data;
+  return {
+    ...rest,
+    isAdmin: is_admin,
+    avatarUrl: avatar_url,
+    defaultAssists: default_assists || [],
+    favoriteSim: favorite_sim || '',
+    favoriteTrack: favorite_track || '',
+    favoriteCar: favorite_car || '',
+    wheel: wheel || '',
+    frame: frame || '',
+    brakes: brakes || '',
+    equipment: equipment || '',
+    league: league || '',
+  } as User;
 }
 
 export async function getUserStats(): Promise<UserStats> {

--- a/frontend/src/pages/ProfilePage.test.tsx
+++ b/frontend/src/pages/ProfilePage.test.tsx
@@ -3,12 +3,24 @@ import ProfilePage from './ProfilePage';
 import { useAuth } from '../contexts/AuthContext';
 
 jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
-jest.mock('../api', () => ({ getUserStats: () => Promise.resolve({ lapCount: 0, bestLapMs: null, avgLapMs: null }), uploadFile: jest.fn(), updateProfile: jest.fn() }));
+jest.mock('../api', () => ({
+  getUserStats: () => Promise.resolve({ lapCount: 0, bestLapMs: null, avgLapMs: null }),
+  uploadFile: jest.fn(),
+  updateProfile: jest.fn(),
+  getAssists: () => Promise.resolve([]),
+}));
 
 const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 beforeEach(() => {
-  mockedUseAuth.mockReturnValue({ user: { id: '1', username: 'u', email: 'e' }, isLoading: false, login: jest.fn(), register: jest.fn(), logout: jest.fn(), refreshUser: jest.fn() });
+  mockedUseAuth.mockReturnValue({
+    user: { id: '1', username: 'u', email: 'e', defaultAssists: [] },
+    isLoading: false,
+    login: jest.fn(),
+    register: jest.fn(),
+    logout: jest.fn(),
+    refreshUser: jest.fn(),
+  });
 });
 
 test('renders profile heading', async () => {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,22 +1,47 @@
 import React, { useEffect, useState } from 'react';
 import { User as UserIcon } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-import { uploadFile, updateProfile, getUserStats } from '../api';
+import { uploadFile, updateProfile, getUserStats, getAssists } from '../api';
 import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
 import { Button } from '../components/ui/button';
 import { toast } from 'sonner';
 import { getInitials, getImageUrl } from '../utils';
 import { formatTime } from '../utils/time';
-import { UserStats } from '../types';
+import { UserStats, Assist } from '../types';
 
 const ProfilePage: React.FC = () => {
   const { user, refreshUser } = useAuth();
   const [stats, setStats] = useState<UserStats | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [assists, setAssists] = useState<Assist[]>([]);
+
+  const [wheel, setWheel] = useState('');
+  const [frame, setFrame] = useState('');
+  const [brakes, setBrakes] = useState('');
+  const [equipment, setEquipment] = useState('');
+  const [favoriteSim, setFavoriteSim] = useState('');
+  const [favoriteTrack, setFavoriteTrack] = useState('');
+  const [favoriteCar, setFavoriteCar] = useState('');
+  const [league, setLeague] = useState('');
+  const [defaultAssists, setDefaultAssists] = useState<string[]>([]);
 
   useEffect(() => {
     getUserStats().then(setStats).catch(() => {});
+    getAssists().then(setAssists).catch(() => {});
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    setWheel(user.wheel || '');
+    setFrame(user.frame || '');
+    setBrakes(user.brakes || '');
+    setEquipment(user.equipment || '');
+    setFavoriteSim(user.favoriteSim || '');
+    setFavoriteTrack(user.favoriteTrack || '');
+    setFavoriteCar(user.favoriteCar || '');
+    setLeague(user.league || '');
+    setDefaultAssists(user.defaultAssists || []);
+  }, [user]);
 
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -81,6 +106,121 @@ const ProfilePage: React.FC = () => {
           </p>
         </div>
       )}
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          try {
+            await updateProfile({
+              wheel,
+              frame,
+              brakes,
+              equipment,
+              favoriteSim,
+              favoriteTrack,
+              favoriteCar,
+              league,
+              defaultAssists,
+            });
+            toast.success('Profile updated');
+            await refreshUser();
+          } catch (err) {
+            toast.error('Failed to update profile');
+            console.error(err);
+          }
+        }}
+        className="space-y-4"
+      >
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Wheel</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={wheel}
+            onChange={(e) => setWheel(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Frame</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={frame}
+            onChange={(e) => setFrame(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Brakes</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={brakes}
+            onChange={(e) => setBrakes(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Other Equipment</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={equipment}
+            onChange={(e) => setEquipment(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Favorite Sim/Game</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={favoriteSim}
+            onChange={(e) => setFavoriteSim(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Favorite Track</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={favoriteTrack}
+            onChange={(e) => setFavoriteTrack(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Favorite Car</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={favoriteCar}
+            onChange={(e) => setFavoriteCar(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">League</label>
+          <input
+            className="w-full rounded border px-3 py-2"
+            value={league}
+            onChange={(e) => setLeague(e.target.value)}
+            placeholder="Optional"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="block text-sm font-medium">Default Assists</label>
+          <div className="grid grid-cols-2 gap-2">
+            {assists.map((a) => (
+              <label key={a.id} className="flex items-center space-x-1">
+                <input
+                  type="checkbox"
+                  checked={defaultAssists.includes(a.id)}
+                  onChange={() =>
+                    setDefaultAssists((prev) =>
+                      prev.includes(a.id)
+                        ? prev.filter((id) => id !== a.id)
+                        : [...prev, a.id]
+                    )
+                  }
+                  className="accent-primary"
+                />
+                <span>{a.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+        <Button type="submit" className="w-full">
+          Save
+        </Button>
+      </form>
     </div>
   );
 };

--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -97,7 +97,10 @@ const SubmitLapTimePage: React.FC = () => {
         if (obj.inputType) setInputType(obj.inputType);
       } catch {}
     }
-  }, []);
+    if (user && user.defaultAssists && user.defaultAssists.length > 0) {
+      setSelectedAssists(user.defaultAssists);
+    }
+  }, [user]);
 
   useEffect(() => {
     if (gameId) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,6 +4,15 @@ export interface User {
   email: string;
   avatarUrl?: string | null;
   isAdmin?: boolean;
+  wheel?: string | null;
+  frame?: string | null;
+  brakes?: string | null;
+  equipment?: string | null;
+  favoriteSim?: string | null;
+  favoriteTrack?: string | null;
+  favoriteCar?: string | null;
+  defaultAssists?: string[];
+  league?: string | null;
 }
 
 export interface UserStats {


### PR DESCRIPTION
## Summary
- expand users table with rig setup, favorites, default assists
- support new fields in user API routes
- map profile data in auth and users client helpers
- extend TypeScript User type
- flesh out ProfilePage with form to edit new fields
- pre-fill assists in SubmitLapTimePage using user defaults
- update ProfilePage test mocks

## Testing
- `npm test` within `backend`
- `pnpm test` within `frontend`

------
https://chatgpt.com/codex/tasks/task_e_68557142dacc83219084c712d3bc84e0