### PR TITLE
Fix user API name clash

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -96,7 +96,7 @@ export async function importDatabase(
   return res.data;
 }
 
-export async function getUsers(): Promise<User[]> {
+export async function getAdminUsers(): Promise<User[]> {
   const res = await apiClient.get('/admin/users');
   return res.data;
 }

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -11,7 +11,7 @@ const mockedApi = {
   verifyLapTime: jest.fn(),
   deleteLapTime: jest.fn(),
   getVersion: jest.fn(),
-  getUsers: jest.fn(),
+  getAdminUsers: jest.fn(),
   createUser: jest.fn(),
   updateUser: jest.fn(),
   deleteUser: jest.fn(),
@@ -27,7 +27,7 @@ beforeEach(() => {
   mockedApi.getTracks.mockResolvedValue([]);
   mockedApi.getLayouts.mockResolvedValue([]);
   mockedApi.getCars.mockResolvedValue([]);
-  mockedApi.getUsers.mockResolvedValue([]);
+  mockedApi.getAdminUsers.mockResolvedValue([]);
   mockedApi.getVersion.mockResolvedValue({ appVersion: 'v0.1', dbVersion: 'v1' });
 });
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -25,7 +25,7 @@ import {
   exportDatabase,
   importDatabase,
   getVersion,
-  getUsers,
+  getAdminUsers,
   createUser,
   updateUser,
   deleteUser,
@@ -115,7 +115,7 @@ const AdminPage: React.FC = () => {
     getTracks().then(setTracks).catch(() => {});
     getLayouts().then(setLayouts).catch(() => {});
     getCars().then(setCars).catch(() => {});
-    getUsers().then(setUsers).catch(() => {});
+    getAdminUsers().then(setUsers).catch(() => {});
     getVersion()
       .then((v) => {
         setAppVersion(v.appVersion);
@@ -128,7 +128,7 @@ const AdminPage: React.FC = () => {
   const refreshTracks = () => getTracks().then(setTracks).catch(() => {});
   const refreshLayouts = () => getLayouts().then(setLayouts).catch(() => {});
   const refreshCars = () => getCars().then(setCars).catch(() => {});
-  const refreshUsers = () => getUsers().then(setUsers).catch(() => {});
+  const refreshUsers = () => getAdminUsers().then(setUsers).catch(() => {});
 
   const updateGameRow = async (id: string, data: Partial<Game>) => {
     const existing = games.find((g) => g.id === id);

--- a/frontend/src/pages/LapTimesPage.tsx
+++ b/frontend/src/pages/LapTimesPage.tsx
@@ -25,7 +25,7 @@ const LapTimesPage: React.FC = () => {
   const [games, setGames] = useState<Game[]>([]);
   const [tracks, setTracks] = useState<Track[]>([]);
   const [cars, setCars] = useState<Car[]>([]);
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<Pick<User, 'id' | 'username'>[]>([]);
   const [assists, setAssists] = useState<Assist[]>([]);
   const [filters, setFilters] = useState({
     gameId: '',


### PR DESCRIPTION
## Summary
- rename admin user retrieval to `getAdminUsers`
- update admin page and tests for new name
- type users list in lap times page to match API

## Testing
- `pnpm test` in `frontend`
- `npm test` in `backend`
- `pnpm build` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685571c601008321bdc95698c67fe0e8