### PR TITLE
Add admin info search

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ npm test      # from ./backend
 pnpm test     # from ./frontend
 ```
 
+## Scraper Script
+
+The backend includes a small utility that can fetch track or car information
+from Wikipedia. Use it to quickly populate images and descriptions:
+
+```bash
+node backend/scrapers/scrapeInfo.js "Monza" "Ferrari 488 GT3"
+```
+
+The script outputs JSON containing the page title, short description and a
+thumbnail image URL for each term. Provide any number of Wikipedia page titles
+as arguments.
+
+The Admin interface includes a new **Info Search** page that uses this scraper.
+Admins can search Wikipedia for a game, track, layout or car and save the
+resulting title, description and thumbnail directly to the database.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,24 +10,30 @@
     "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "helmet": "^7.0.0",
+    "axios": "^1.10.0",
     "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.1",
-    "pg": "^8.11.1",
-    "multer": "^1.4.5-lts.1",
-    "express-validator": "^7.0.1",
-    "dotenv": "^16.3.1",
     "compression": "^1.7.4",
-    "express-rate-limit": "^6.8.1"
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.8.1",
+    "express-validator": "^7.0.1",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.1",
+    "multer": "^1.4.5-lts.1",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1",
     "jest": "^29.6.1",
+    "nodemon": "^3.0.1",
     "supertest": "^7.1.1"
   },
-  "keywords": ["racing", "lap-times", "simulator", "api"],
+  "keywords": [
+    "racing",
+    "lap-times",
+    "simulator",
+    "api"
+  ],
   "author": "MiniMax Agent",
   "license": "MIT"
 }

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -2,6 +2,7 @@ const express = require('express');
 const db = require('../utils/database');
 const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
+const { fetchWikipediaInfo } = require('../scrapers/scrapeInfo');
 
 const router = express.Router();
 
@@ -65,6 +66,19 @@ router.delete('/lapTimes/:id', auth, admin, async (req, res, next) => {
       return res.status(404).json({ message: 'Lap time not found' });
     }
     res.json(result.rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/search', auth, admin, async (req, res, next) => {
+  const { title } = req.query;
+  if (!title) {
+    return res.status(400).json({ message: 'title query required' });
+  }
+  try {
+    const info = await fetchWikipediaInfo(title);
+    res.json(info);
   } catch (err) {
     next(err);
   }

--- a/backend/scrapers/scrapeInfo.js
+++ b/backend/scrapers/scrapeInfo.js
@@ -1,0 +1,39 @@
+const axios = require('axios');
+
+async function fetchWikipediaInfo(title) {
+  const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
+  const { data } = await axios.get(url, {
+    headers: { 'User-Agent': 'RacingLapTracker/1.0 (https://github.com/yourproject)' },
+    maxRedirects: 5,
+    timeout: 10000
+  });
+  return {
+    title: data.title,
+    description: data.extract,
+    imageUrl: data.thumbnail ? data.thumbnail.source : null
+  };
+}
+
+async function main() {
+  const terms = process.argv.slice(2);
+  if (terms.length === 0) {
+    console.error('Usage: node scrapeInfo.js <title1> [title2 ...]');
+    process.exit(1);
+  }
+  const results = [];
+  for (const term of terms) {
+    try {
+      const info = await fetchWikipediaInfo(term);
+      results.push(info);
+    } catch (err) {
+      console.error(`Error fetching ${term}:`, err.message);
+    }
+  }
+  console.log(JSON.stringify(results, null, 2));
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { fetchWikipediaInfo };

--- a/backend/tests/searchRoute.test.js
+++ b/backend/tests/searchRoute.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest');
+const app = require('../server');
+
+jest.mock('../middleware/auth', () => jest.fn((req, res, next) => { req.user = { id: 'admin' }; next(); }));
+jest.mock('../middleware/admin', () => jest.fn((req, res, next) => next()));
+
+jest.mock('../scrapers/scrapeInfo', () => ({
+  fetchWikipediaInfo: jest.fn(),
+}));
+
+const { fetchWikipediaInfo } = require('../scrapers/scrapeInfo');
+
+describe('Admin search route', () => {
+  beforeEach(() => {
+    fetchWikipediaInfo.mockReset();
+  });
+
+  it('returns info for a title', async () => {
+    fetchWikipediaInfo.mockResolvedValue({ title: 'Monza', description: 'd', imageUrl: 'img' });
+    const res = await request(app).get('/api/admin/search?title=Monza');
+    expect(res.status).toBe(200);
+    expect(res.body.title).toBe('Monza');
+    expect(fetchWikipediaInfo).toHaveBeenCalledWith('Monza');
+  });
+
+  it('requires title query', async () => {
+    const res = await request(app).get('/api/admin/search');
+    expect(res.status).toBe(400);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import ProfilePage from './pages/ProfilePage';
 import LapTimesPage from './pages/LapTimesPage';
 import SubmitLapTimePage from './pages/SubmitLapTimePage';
 import AdminPage from './pages/AdminPage';
+import InfoSearchPage from './pages/InfoSearchPage';
 import TrackDetailPage from './pages/TrackDetailPage';
 import CarDetailPage from './pages/CarDetailPage';
 import './App.css';
@@ -64,13 +65,21 @@ function App() {
                       </ProtectedRoute>
                     } 
                   />
-                  <Route 
-                    path="/admin" 
+                  <Route
+                    path="/admin"
                     element={
                       <ProtectedRoute requireAdmin>
                         <AdminPage />
                       </ProtectedRoute>
-                    } 
+                    }
+                  />
+                  <Route
+                    path="/admin/search"
+                    element={
+                      <ProtectedRoute requireAdmin>
+                        <InfoSearchPage />
+                      </ProtectedRoute>
+                    }
                   />
                 </Route>
                 

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -115,3 +115,8 @@ export async function deleteUser(id: string, keepTimes?: boolean): Promise<any> 
   const res = await apiClient.delete(`/admin/users/${id}`, { params: { keepTimes } });
   return res.data;
 }
+
+export async function searchInfo(title: string) {
+  const res = await apiClient.get('/admin/search', { params: { title } });
+  return res.data as { title: string; description: string; imageUrl: string | null };
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -7,9 +7,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { 
   Timer,
   PlusCircle, 
-  User, 
-  Settings, 
-  LogOut, 
+  User,
+  Settings,
+  Search,
+  LogOut,
   Menu,
   Moon,
   Sun
@@ -119,6 +120,14 @@ const Header: React.FC = () => {
                     <Link to="/admin" className="cursor-pointer">
                       <Settings className="mr-2 h-4 w-4" />
                       <span>Admin</span>
+                    </Link>
+                  </DropdownMenuItem>
+                )}
+                {user.isAdmin && (
+                  <DropdownMenuItem asChild>
+                    <Link to="/admin/search" className="cursor-pointer">
+                      <Search className="mr-2 h-4 w-4" />
+                      <span>Info Search</span>
                     </Link>
                   </DropdownMenuItem>
                 )}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -339,6 +339,9 @@ const AdminPage: React.FC = () => {
       <div className="flex items-center space-x-2 mb-4">
         <Settings className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Admin</h1>
+        <Link to="/admin/search" className="underline text-sm ml-2">
+          Info Search
+        </Link>
       </div>
 
       <section>

--- a/frontend/src/pages/InfoSearchPage.test.tsx
+++ b/frontend/src/pages/InfoSearchPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import InfoSearchPage from './InfoSearchPage';
+import * as api from '../api';
+
+jest.mock('../api', () => ({
+  searchInfo: jest.fn(),
+  createGame: jest.fn(),
+  createTrack: jest.fn(),
+  createLayout: jest.fn(),
+  createCar: jest.fn(),
+  getGames: jest.fn(),
+  getTracks: jest.fn(),
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+beforeEach(() => {
+  mockedApi.searchInfo.mockResolvedValue({ title: 'Monza', description: 'd', imageUrl: '/img' });
+  mockedApi.getGames.mockResolvedValue([]);
+  mockedApi.getTracks.mockResolvedValue([]);
+});
+
+test('searches and saves a game', async () => {
+  render(
+    <MemoryRouter>
+      <InfoSearchPage />
+    </MemoryRouter>
+  );
+  await userEvent.type(screen.getByPlaceholderText(/search/i), 'Monza');
+  await userEvent.click(screen.getByRole('button', { name: /search/i }));
+  expect(await screen.findByText('Monza')).toBeInTheDocument();
+  await userEvent.click(screen.getByRole('button', { name: /save/i }));
+  expect(mockedApi.createGame).toHaveBeenCalled();
+});

--- a/frontend/src/pages/InfoSearchPage.tsx
+++ b/frontend/src/pages/InfoSearchPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { Search, Settings } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import {
+  searchInfo,
+  createGame,
+  createTrack,
+  createLayout,
+  createCar,
+  getGames,
+  getTracks,
+} from '../api';
+import { Button } from '../components/ui/button';
+
+const InfoSearchPage: React.FC = () => {
+  const [term, setTerm] = useState('');
+  const [result, setResult] = useState<{ title: string; description: string; imageUrl: string | null } | null>(null);
+  const [type, setType] = useState<'game' | 'track' | 'layout' | 'car'>('game');
+  const [games, setGames] = useState<any[]>([]);
+  const [tracks, setTracks] = useState<any[]>([]);
+  const [gameId, setGameId] = useState('');
+  const [trackId, setTrackId] = useState('');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    getGames().then(setGames).catch(() => {});
+    getTracks().then(setTracks).catch(() => {});
+  }, []);
+
+  const handleSearch = async () => {
+    if (!term.trim()) return;
+    const info = await searchInfo(term.trim());
+    setResult(info);
+    setMessage('');
+  };
+
+  const handleSave = async () => {
+    if (!result) return;
+    if (type === 'game') {
+      await createGame({ name: result.title, imageUrl: result.imageUrl, description: result.description });
+    } else if (type === 'track') {
+      if (!gameId) return;
+      await createTrack({ gameId, name: result.title, imageUrl: result.imageUrl, description: result.description });
+    } else if (type === 'layout') {
+      if (!trackId) return;
+      await createLayout({ trackId, name: result.title, imageUrl: result.imageUrl });
+    } else if (type === 'car') {
+      if (!gameId) return;
+      await createCar({ gameId, name: result.title, imageUrl: result.imageUrl, description: result.description });
+    }
+    setMessage('Saved');
+  };
+
+  return (
+    <div className="container mx-auto py-6 space-y-4">
+      <div className="flex items-center space-x-2 mb-4">
+        <Settings className="h-6 w-6" />
+        <h1 className="text-3xl font-bold">Info Search</h1>
+        <Link to="/admin" className="text-sm underline ml-2">Back to Admin</Link>
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="border p-1 flex-1"
+          placeholder="Search Wikipedia"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+        />
+        <Button size="sm" onClick={handleSearch}>
+          <Search className="h-4 w-4 mr-1" /> Search
+        </Button>
+      </div>
+      {result && (
+        <div className="border p-4 space-y-2">
+          <h2 className="text-lg font-semibold">{result.title}</h2>
+          {result.imageUrl && <img src={result.imageUrl} alt={result.title} className="h-32" />}
+          <p className="text-sm whitespace-pre-line">{result.description}</p>
+          <div className="flex flex-wrap items-end gap-2">
+            <select value={type} onChange={(e) => setType(e.target.value as any)} className="border p-1">
+              <option value="game">Game</option>
+              <option value="track">Track</option>
+              <option value="layout">Layout</option>
+              <option value="car">Car</option>
+            </select>
+            {(type === 'track' || type === 'car') && (
+              <select value={gameId} onChange={(e) => setGameId(e.target.value)} className="border p-1">
+                <option value="">Game</option>
+                {games.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            {type === 'layout' && (
+              <select value={trackId} onChange={(e) => setTrackId(e.target.value)} className="border p-1">
+                <option value="">Track</option>
+                {tracks.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            <Button size="sm" onClick={handleSave}>Save</Button>
+            {message && <span className="text-green-600 text-sm">{message}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InfoSearchPage;


### PR DESCRIPTION
## Summary
- expose Wikipedia scrape via `/api/admin/search`
- add Info Search page to admin UI
- link to new page from header and admin page
- document Info Search in README
- test new API route and page

## Testing
- `npm test --silent` in `backend`
- `pnpm test --silent` in `frontend`
- ❌ `node backend/scrapers/scrapeInfo.js Monza "Ferrari 488 GT3"` (fails: Maximum number of redirects exceeded)


------
https://chatgpt.com/codex/tasks/task_e_68557684326083219f127bbc2d3e6903