### PR TITLE
Store uploads in shared images folder

### DIFF
--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -6,7 +6,9 @@ const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
 const router = express.Router();
 
-const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
+const uploadDir =
+  process.env.UPLOAD_DIR ||
+  path.join(__dirname, '..', '..', 'frontend', 'public', 'images');
 function sanitizeFilename(name) {
   return name
     .replace(/[^a-z0-9._-]/gi, '_')
@@ -82,7 +84,7 @@ router.post('/', auth, (req, res, next) => {
         return next(err);
       }
       const prefix = folder ? `${folder}/` : '';
-      res.json({ url: `/uploads/${prefix}${req.file.filename}` });
+      res.json({ url: `/images/${prefix}${req.file.filename}` });
     });
 
   if (adminFolders.some((f) => folder.startsWith(f))) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -35,9 +35,9 @@ app.use(compression());
 app.use(express.json({ limit: '5mb' }));
 app.use(express.urlencoded({ extended: false, limit: '5mb' }));
 
-// Ensure uploads directory exists and serve static files
+// Ensure image upload directory exists and serve static files
 fs.mkdirSync(uploadDir, { recursive: true });
-app.use('/uploads', express.static(uploadDir));
+app.use('/images', express.static(uploadDir));
 
 // Basic rate limiting
 const limiter = rateLimit({ windowMs: 1 * 60 * 1000, max: 100 });

--- a/backend/tests/uploadRoutes.test.js
+++ b/backend/tests/uploadRoutes.test.js
@@ -43,7 +43,7 @@ describe('Upload routes', () => {
       .attach('file', pngBuffer, 'test.png');
 
     expect(res.status).toBe(200);
-    expect(res.body.url).toMatch(/^\/uploads\/.*\.png$/);
+    expect(res.body.url).toMatch(/^\/images\/.*\.png$/);
 
     const storedPath = path.join(tmpDir, path.basename(res.body.url));
     expect(fs.existsSync(storedPath)).toBe(true);
@@ -60,7 +60,7 @@ describe('Upload routes', () => {
       .attach('file', pngBuffer, { filename: 'test.png', contentType: 'image/x-png' });
 
     expect(res.status).toBe(200);
-    expect(res.body.url).toMatch(/^\/uploads\/.*\.png$/);
+    expect(res.body.url).toMatch(/^\/images\/.*\.png$/);
 
     const storedPath = path.join(tmpDir, path.basename(res.body.url));
     expect(fs.existsSync(storedPath)).toBe(true);

--- a/backend/tests/userRoutes.test.js
+++ b/backend/tests/userRoutes.test.js
@@ -13,11 +13,11 @@ describe('User routes', () => {
   });
 
   it('updates profile', async () => {
-    db.query.mockResolvedValue({ rows: [{ id: 'u1', username: 'test', email: 'a@b.c', is_admin: false, avatar_url: '/uploads/a.jpg' }] });
-    const res = await request(app).put('/api/users/me').send({ avatarUrl: '/uploads/a.jpg' });
+    db.query.mockResolvedValue({ rows: [{ id: 'u1', username: 'test', email: 'a@b.c', is_admin: false, avatar_url: '/images/a.jpg' }] });
+    const res = await request(app).put('/api/users/me').send({ avatarUrl: '/images/a.jpg' });
     expect(res.status).toBe(200);
     expect(db.query).toHaveBeenCalled();
-    expect(res.body.avatar_url).toBe('/uploads/a.jpg');
+    expect(res.body.avatar_url).toBe('/images/a.jpg');
   });
 
   it('returns user stats', async () => {


### PR DESCRIPTION
## Summary
- save uploads to `frontend/public/images`
- serve uploaded images from `/images`
- update upload route return paths
- adjust tests for new image path

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_685645159a8883219af6a9969b61386c