### PR TITLE
Fix upload path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ npm run dev  # or `npm start` for production
 
 Environment variables can be configured in `backend/.env` (see `backend/.env.example`).
 
-Uploaded files are stored in the `backend/uploads` directory by default. The server
-creates this folder automatically on startup and serves its contents at `/uploads`.
-You can change the location by setting the `UPLOAD_DIR` environment variable.
+Uploaded files are stored in the `frontend/public/images` directory by default.
+The server creates this folder automatically on startup and serves its contents
+at `/uploads`. You can change the location by setting the `UPLOAD_DIR`
+environment variable.
 
 ## Frontend Setup
 
@@ -75,7 +76,7 @@ loads the records from `database/sample_lap_times.json`. This means the sample
 lap times appear automatically on a fresh installation.
 
 Database data is stored in the `db-data` volume and uploaded files are kept in
-`backend/uploads`.
+`frontend/public/images`.
 
 ## Database Setup
 

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -6,7 +6,9 @@ const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
 const router = express.Router();
 
-const uploadDir = process.env.UPLOAD_DIR || path.join(__dirname, '..', 'uploads');
+const uploadDir =
+  process.env.UPLOAD_DIR ||
+  path.join(__dirname, '..', '..', 'frontend', 'public', 'images');
 function sanitizeFilename(name) {
   return name
     .replace(/[^a-z0-9._-]/gi, '_')


### PR DESCRIPTION
## Summary
- store uploads in the frontend `public/images` folder
- document new default upload location

## Testing
- `npm test` from `./backend`
- `pnpm test` from `./frontend`


------
https://chatgpt.com/codex/tasks/task_e_68566d05a1688321a5046d3161e0c5a5