### PR TITLE
Update uploads directory config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ npm install
 npm run dev  # or `npm start` for production
 ```
 
-Environment variables can be configured in `backend/.env` (see `backend/.env.example`).
+Environment variables can be configured in `backend/.env` (see
+`backend/.env.example`).
 
-Uploaded files are stored in the `frontend/public/images` directory by default.
-The server creates this folder automatically on startup and serves its contents
-at `/uploads`. You can change the location by setting the `UPLOAD_DIR`
-environment variable.
+Uploaded files are stored in the `frontend/public/images` directory. The server
+creates this folder automatically on startup and serves its contents at
+`/uploads`. Both `.env.example` and `docker-compose.yml` set
+`UPLOAD_DIR=../frontend/public/images` so the backend writes directly to the
+frontend's image folder. The path is resolved to an absolute location on start
+and printed to the console. You may point `UPLOAD_DIR` elsewhere if desired,
+using either an absolute path or one relative to the backend directory.
 
 ## Frontend Setup
 
@@ -76,7 +80,8 @@ loads the records from `database/sample_lap_times.json`. This means the sample
 lap times appear automatically on a fresh installation.
 
 Database data is stored in the `db-data` volume and uploaded files are kept in
-`frontend/public/images`.
+`frontend/public/images`, which is mounted into both the backend and frontend
+containers.
 
 ## Database Setup
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,6 @@
 DATABASE_URL=postgres://postgres:postgres@db:5432/racing
 JWT_SECRET=your_jwt_secret
 PORT=5000
-UPLOAD_DIR=uploads
+UPLOAD_DIR=../frontend/public/images
 APP_VERSION=v0.1
 DB_VERSION=v1

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -6,9 +6,10 @@ const auth = require('../middleware/auth');
 const admin = require('../middleware/admin');
 const router = express.Router();
 
-const uploadDir =
+const uploadDir = path.resolve(
   process.env.UPLOAD_DIR ||
-  path.join(__dirname, '..', '..', 'frontend', 'public', 'images');
+    path.join(__dirname, '..', '..', 'frontend', 'public', 'images')
+);
 function sanitizeFilename(name) {
   return name
     .replace(/[^a-z0-9._-]/gi, '_')

--- a/backend/server.js
+++ b/backend/server.js
@@ -37,6 +37,7 @@ app.use(express.urlencoded({ extended: false, limit: '5mb' }));
 
 // Ensure uploads directory exists and serve static files
 fs.mkdirSync(uploadDir, { recursive: true });
+console.log(`Uploads directory: ${uploadDir}`);
 app.use('/uploads', express.static(uploadDir));
 
 // Basic rate limiting

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,9 +25,9 @@ services:
       DATABASE_URL: postgres://postgres:postgres@db:5432/racing
       JWT_SECRET: supersecret
       PORT: 5000
-      UPLOAD_DIR: uploads
+      UPLOAD_DIR: ../frontend/public/images
     volumes:
-      - ./backend/uploads:/usr/src/app/uploads
+      - ./frontend/public/images:/usr/src/frontend/public/images
       - ./database:/usr/src/database:ro
     depends_on:
       db:


### PR DESCRIPTION
## Summary
- ensure `UPLOAD_DIR` resolves to an absolute path
- log the final uploads directory on server start
- clarify uploads path resolution in README

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685670bbb57883219da916615bc9f645