### PR TITLE
Fix upload directory default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Environment variables can be configured in `backend/.env` (see
 Uploaded files are stored in the `frontend/public/images` directory. The server
 creates this folder automatically on startup and serves its contents at
 `/uploads`. Both `.env.example` and `docker-compose.yml` set
-`UPLOAD_DIR=../frontend/public/images` so the backend writes directly to the
+`UPLOAD_DIR=../frontend/public` so the backend writes directly to the
 
 frontend's image folder. The path is resolved to an absolute location on start
 and printed to the console. You may point `UPLOAD_DIR` elsewhere if desired,

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,6 @@
 DATABASE_URL=postgres://postgres:postgres@db:5432/racing
 JWT_SECRET=your_jwt_secret
 PORT=5000
-UPLOAD_DIR=../frontend/public/images
+UPLOAD_DIR=../frontend/public
 APP_VERSION=v0.1
 DB_VERSION=v1

--- a/backend/routes/uploads.js
+++ b/backend/routes/uploads.js
@@ -8,7 +8,7 @@ const router = express.Router();
 
 const uploadDir = path.resolve(
   process.env.UPLOAD_DIR ||
-    path.join(__dirname, '..', '..', 'frontend', 'public', 'images')
+    path.join(__dirname, '..', '..', 'frontend', 'public')
 );
 function sanitizeFilename(name) {
   return name

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       DATABASE_URL: postgres://postgres:postgres@db:5432/racing
       JWT_SECRET: supersecret
       PORT: 5000
-      UPLOAD_DIR: ../frontend/public/images
+      UPLOAD_DIR: ../frontend/public
     volumes:
       - ./frontend/public/images:/usr/src/frontend/public/images
       - ./database:/usr/src/database:ro


### PR DESCRIPTION
## Summary
- default uploads path to `frontend/public`
- update env example and docker-compose
- document new path in README

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68569833ea788321b60f11556f973bd4