### PR TITLE
Fix screenshot upload directory

### DIFF
--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -202,7 +202,7 @@ const SubmitLapTimePage: React.FC = () => {
     try {
       let screenshotUrl: string | undefined;
       if (screenshot) {
-        const res = await uploadFile(screenshot);
+        const res = await uploadFile(screenshot, 'images');
         screenshotUrl = res.url;
       }
       const combinedNotes = deviceModel


### PR DESCRIPTION
## Summary
- store lap time screenshots in the `images` folder

## Testing
- `npm test --silent` from `backend`
- `pnpm test --silent` from `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6856a5f343448321871cd9269d8d3f33