### PR TITLE
Update info search to store wiki results

### DIFF
--- a/frontend/src/pages/InfoSearchPage.test.tsx
+++ b/frontend/src/pages/InfoSearchPage.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../api', () => ({
   createCar: jest.fn(),
   getGames: jest.fn(),
   getTracks: jest.fn(),
+  uploadFile: jest.fn(),
 }));
 
 const mockedApi = api as jest.Mocked<typeof api>;
@@ -20,6 +21,10 @@ beforeEach(() => {
   mockedApi.searchInfo.mockResolvedValue({ title: 'Monza', description: 'd', imageUrl: '/img' });
   mockedApi.getGames.mockResolvedValue([]);
   mockedApi.getTracks.mockResolvedValue([]);
+  mockedApi.uploadFile.mockResolvedValue({ url: '/local/img.jpg' });
+  global.fetch = jest.fn().mockResolvedValue({
+    blob: () => Promise.resolve(new Blob(['img'], { type: 'image/jpeg' })),
+  }) as any;
 });
 
 test('searches and saves a game', async () => {


### PR DESCRIPTION
## Summary
- download Wikipedia thumbnails via fetch
- upload saved images to images folder
- store descriptions via existing markdown write
- update InfoSearchPage test for new image upload

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6856a85674a88321a81dff2a4f5537d0