### PR TITLE
Add update mode and image search

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,8 @@
     "helmet": "^7.0.0",
     "jsonwebtoken": "^9.0.1",
     "multer": "^1.4.5-lts.1",
-    "pg": "^8.11.1"
+    "pg": "^8.11.1",
+    "duckduckgo-images-api": "^1.0.5"
   },
   "devDependencies": {
     "jest": "^29.6.1",

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -84,6 +84,22 @@ router.get('/search', auth, admin, async (req, res, next) => {
   }
 });
 
+// Return a few image options using DuckDuckGo image search
+router.get('/images', auth, admin, async (req, res, next) => {
+  const { q } = req.query;
+  if (!q) {
+    return res.status(400).json({ message: 'q query required' });
+  }
+  try {
+    const { image_search } = await import('duckduckgo-images-api');
+    const results = await image_search({ query: q, moderate: true, iterations: 1 });
+    const images = results.slice(0, 4).map((r) => r.image);
+    res.json({ images });
+  } catch (err) {
+    next(err);
+  }
+});
+
 router.get('/export', auth, admin, async (req, res, next) => {
   try {
     const tables = [

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -120,3 +120,8 @@ export async function searchInfo(title: string) {
   const res = await apiClient.get('/admin/search', { params: { title } });
   return res.data as { title: string; description: string; imageUrl: string | null };
 }
+
+export async function searchImages(query: string) {
+  const res = await apiClient.get('/admin/images', { params: { q: query } });
+  return res.data as { images: string[] };
+}

--- a/frontend/src/pages/InfoSearchPage.test.tsx
+++ b/frontend/src/pages/InfoSearchPage.test.tsx
@@ -6,12 +6,19 @@ import * as api from '../api';
 
 jest.mock('../api', () => ({
   searchInfo: jest.fn(),
+  searchImages: jest.fn(),
   createGame: jest.fn(),
   createTrack: jest.fn(),
   createLayout: jest.fn(),
   createCar: jest.fn(),
+  updateGame: jest.fn(),
+  updateTrack: jest.fn(),
+  updateLayout: jest.fn(),
+  updateCar: jest.fn(),
   getGames: jest.fn(),
   getTracks: jest.fn(),
+  getLayouts: jest.fn(),
+  getCars: jest.fn(),
   uploadFile: jest.fn(),
 }));
 
@@ -19,8 +26,11 @@ const mockedApi = api as jest.Mocked<typeof api>;
 
 beforeEach(() => {
   mockedApi.searchInfo.mockResolvedValue({ title: 'Monza', description: 'd', imageUrl: '/img' });
+  mockedApi.searchImages.mockResolvedValue({ images: ['/img'] });
   mockedApi.getGames.mockResolvedValue([]);
   mockedApi.getTracks.mockResolvedValue([]);
+  mockedApi.getLayouts.mockResolvedValue([]);
+  mockedApi.getCars.mockResolvedValue([]);
   mockedApi.uploadFile.mockResolvedValue({ url: '/local/img.jpg' });
   global.fetch = jest.fn().mockResolvedValue({
     blob: () => Promise.resolve(new Blob(['img'], { type: 'image/jpeg' })),


### PR DESCRIPTION
## Summary
- allow searching multiple images via DuckDuckGo
- support updating existing records from Info Search
- expose `/admin/images` API

## Testing
- `npm test --silent --prefix backend`
- `pnpm --dir frontend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856af7e96788321995fa0477e0c31f4