### PR TITLE
Handle Wikipedia 404 errors gracefully

### DIFF
--- a/backend/scrapers/scrapeInfo.js
+++ b/backend/scrapers/scrapeInfo.js
@@ -2,16 +2,28 @@ const axios = require('axios');
 
 async function fetchWikipediaInfo(title) {
   const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
-  const { data } = await axios.get(url, {
-    headers: { 'User-Agent': 'RacingLapTracker/1.0 (https://github.com/yourproject)' },
-    maxRedirects: 5,
-    timeout: 10000
-  });
-  return {
-    title: data.title,
-    description: data.extract,
-    imageUrl: data.thumbnail ? data.thumbnail.source : null
-  };
+  try {
+    const { data } = await axios.get(url, {
+      headers: { 'User-Agent': 'RacingLapTracker/1.0 (https://github.com/yourproject)' },
+      maxRedirects: 5,
+      timeout: 10000
+    });
+    return {
+      title: data.title,
+      description: data.extract,
+      imageUrl: data.thumbnail ? data.thumbnail.source : null
+    };
+  } catch (err) {
+    if (err.response) {
+      const status = err.response.status;
+      const error = new Error(
+        status === 404 ? 'Wikipedia page not found' : 'Failed to fetch Wikipedia info'
+      );
+      error.status = status;
+      throw error;
+    }
+    throw err;
+  }
 }
 
 async function main() {

--- a/backend/tests/searchRoute.test.js
+++ b/backend/tests/searchRoute.test.js
@@ -27,4 +27,13 @@ describe('Admin search route', () => {
     const res = await request(app).get('/api/admin/search');
     expect(res.status).toBe(400);
   });
+
+  it('handles not found error from Wikipedia', async () => {
+    const err = new Error('Wikipedia page not found');
+    err.status = 404;
+    fetchWikipediaInfo.mockRejectedValue(err);
+    const res = await request(app).get('/api/admin/search?title=Unknown');
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('Wikipedia page not found');
+  });
 });


### PR DESCRIPTION
## Summary
- return friendly 404 errors when Wikipedia pages are missing
- add regression test for not-found search error

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6856b26397808321b880d312bd3fb22f