### PR TITLE
Fix image search with updated library

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "jsonwebtoken": "^9.0.1",
     "multer": "^1.4.5-lts.1",
     "pg": "^8.11.1",
-    "duckduckgo-images-api": "^1.0.5"
+    "@mudbill/duckduckgo-images-api": "^2.0.1"
   },
   "devDependencies": {
     "jest": "^29.6.1",

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -91,8 +91,8 @@ router.get('/images', auth, admin, async (req, res, next) => {
     return res.status(400).json({ message: 'q query required' });
   }
   try {
-    const { image_search } = await import('duckduckgo-images-api');
-    const results = await image_search({ query: q, moderate: true, iterations: 1 });
+    const { imageSearch } = await import('@mudbill/duckduckgo-images-api');
+    const results = await imageSearch({ query: q, safe: true, iterations: 1 });
     const images = results.slice(0, 4).map((r) => r.image);
     res.json({ images });
   } catch (err) {


### PR DESCRIPTION
## Summary
- use `@mudbill/duckduckgo-images-api` instead of the outdated library
- update admin image search route to call `imageSearch`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68572112d400832197de1ffa6a2810ec