### PR TITLE
Enable admin editing on car pages

### DIFF
--- a/frontend/src/pages/CarDetailPage.test.tsx
+++ b/frontend/src/pages/CarDetailPage.test.tsx
@@ -9,9 +9,21 @@ const mockedApi = {
 jest.mock('../api', () => mockedApi);
 
 import CarDetailPage from './CarDetailPage';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
 
 describe('CarDetailPage', () => {
   beforeEach(() => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
     mockedApi.getCars.mockResolvedValue([{ id: 'c1', gameId: 'g1', name: 'Car', imageUrl: '' }]);
     mockedApi.getLapTimes.mockResolvedValue([]);
     mockedApi.getWorldRecords.mockResolvedValue([]);
@@ -26,5 +38,43 @@ describe('CarDetailPage', () => {
       </MemoryRouter>
     );
     expect(await screen.findByRole('heading', { name: 'Car' })).toBeInTheDocument();
+  });
+
+  it('shows edit button for admins', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: '1', username: 'admin', email: 'a@b.c', isAdmin: true },
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/car/c1"]}>
+        <Routes>
+          <Route path="/car/:id" element={<CarDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('hides edit button for non-admins', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: '1', username: 'user', email: 'u@b.c', isAdmin: false },
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/car/c1"]}>
+        <Routes>
+          <Route path="/car/:id" element={<CarDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add admin-only edit features to CarDetailPage
- test CarDetailPage admin edit button behaviour

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857359dc0d48321bc5aef1e4ca01667