### PR TITLE
Update version to v1.1 and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,31 @@
 # Racing Lap Time Tracker
 
-This repository contains a simple skeleton for a racing lap time tracker. It is split into three parts:
+**Current version:** v1.1
 
-- **backend** – Node.js/Express API
-- **frontend** – React client built with Vite and pnpm
-- **database** – PostgreSQL schema and seed data
+Racing Lap Time Tracker is a demo application for recording and displaying lap
+records for racing simulation games. The project is split into a Node.js backend
+API, a React frontend and a small PostgreSQL database schema. A Docker Compose
+configuration is provided for a quick local setup.
 
-## Prerequisites
+## Features
+
+- JWT based authentication and basic user profiles
+- Admin interface for verifying lap times and managing users
+- REST API for games, tracks, layouts, cars and lap times
+- Image uploads served from `/api/uploads`
+- Markdown support for descriptions and comments
+- Optional Wikipedia scraper utility for quick data entry
+- Unit tests for both backend and frontend
+
+## Requirements
 
 - [Node.js](https://nodejs.org/) 18 or newer
 - [pnpm](https://pnpm.io/) for the frontend
 - PostgreSQL
 
-## Backend Setup
+## Setup
+
+### Backend
 
 ```bash
 cd backend
@@ -20,135 +33,66 @@ npm install
 npm run dev  # or `npm start` for production
 ```
 
-Environment variables can be configured in `backend/.env` (see
-`backend/.env.example`).
+Configuration lives in `backend/.env` (see `backend/.env.example`). Important
+variables include `DATABASE_URL`, `JWT_SECRET`, `UPLOAD_DIR`, `CONTENT_DIR` and
+`APP_VERSION`.
 
-Uploaded files are stored in the `frontend/public/images` directory. The server
-creates this folder automatically on startup and serves its contents at
-`/uploads`. Both `.env.example` and `docker-compose.yml` set
+Uploaded images are stored in `frontend/public/images` by default. Markdown
+content lives under `frontend/public/content` and is served from `/content`.
 
-`UPLOAD_DIR=../frontend/public` so the backend writes directly to the
-
-
-frontend's image folder. The path is resolved to an absolute location on start
-and printed to the console. You may point `UPLOAD_DIR` elsewhere if desired,
-using either an absolute path or one relative to the backend directory.
-
-Markdown descriptions and comments are stored under
-`frontend/public/content`. The `CONTENT_DIR` environment variable can be used to
-change this location. The backend serves files from this directory at
-`/content`.
-
-See [docs/markdown_samples.md](docs/markdown_samples.md) for examples of the
-small Markdown syntax supported by comments and descriptions on the Track, Game
-and Car pages.
-
-
-## Frontend Setup
+### Frontend
 
 ```bash
 cd frontend
 pnpm install
-pnpm dev   # starts the Vite dev server
+pnpm dev  # starts the Vite dev server
 ```
 
-The development server proxies requests to `/uploads` to the backend so
-uploaded images can be accessed from the same URL as the frontend. Ensure
-`VITE_API_URL` points to your backend instance (for example
-`http://localhost:5000/api`) when running locally or from another device.
+Ensure `VITE_API_URL` points to the backend API (e.g. `http://localhost:5000/api`).
+Use `pnpm build` to create a production bundle.
 
-Use `pnpm build` to create a production build.
+### Docker Compose
 
-## Docker Compose
+A `docker-compose.yml` file sets up PostgreSQL, the backend and the frontend:
 
-The repository ships with a `docker-compose.yml` configuration for a quick
-development setup. It starts PostgreSQL, the backend API and the frontend app.
+1. Copy `backend/.env.example` to `backend/.env` and adjust as needed.
+2. Copy `.env.example` to `.env` and set `VITE_API_URL` to the public API URL.
+3. Run `docker compose build --no-cache frontend` and then `docker compose up -d`.
+4. Visit `http://localhost:5173` to access the UI.
 
-1. Copy `backend/.env.example` to `backend/.env` and adjust the variables if
-   needed (especially `JWT_SECRET`). The default `DATABASE_URL` points to the
-   `db` service used by Docker Compose.
-2. Copy `.env.example` to `.env` and set `VITE_API_URL` to the publicly
-   reachable URL of the backend, for example `http://localhost:5000/api`.
-3. Ensure the `database` directory is present; Docker Compose mounts it
-   read-only to the backend so the sample lap times can be imported
-   automatically on first startup.
-4. The `db` service includes a healthcheck so the backend waits for PostgreSQL
-   to accept connections before starting.
-5. Run `docker compose build --no-cache frontend` followed by
-   `docker compose up -d` from the project root. Docker Compose loads
-   variables from `.env` automatically. Building the images requires
-   internet access. The `frontend/Dockerfile` runs `npm install -g pnpm`, which
-   downloads packages from `registry.npmjs.org`; without a network connection
-   this step fails with `EAI_AGAIN`.
-6. Visit `http://localhost:5173` to access the UI. The API will be available at
+Database data is stored in the `db-data` volume and images are written to
+`frontend/public/images`, which is mounted into both containers.
 
-   `http://localhost:5000`.
+### Database
 
-When the `db` service starts for the first time it runs the SQL files from the
-`database` directory automatically, so the schema and seed data are loaded
-without any manual steps.
-
-On startup the backend checks if the `lap_times` table is empty and, if so,
-loads the records from `database/sample_lap_times.json`. This means the sample
-lap times appear automatically on a fresh installation.
-
-Database data is stored in the `db-data` volume and uploaded files are kept in
-`frontend/public/images`, which is mounted into both the backend and frontend
-containers.
-
-## Database Setup
-
-Create a PostgreSQL database and apply the schema and seed files:
+To initialise a standalone database manually run:
 
 ```bash
 psql -U <user> -d <database> -f database/schema.sql
 psql -U <user> -d <database> -f database/seed_data.sql
 ```
 
-When running with Docker Compose, these files are mounted to the `db` service
-and executed automatically on the first start. Simply remove the `db-data`
-volume and run `docker compose up -d` again to reset the database.
+Sample lap times from `database/sample_lap_times.json` are loaded on first start
+when the table is empty.
 
-Adjust connection settings in your backend environment variables as needed.
-
-**Note**: The Admin page's Import function accepts JSON files created via the
-Export button. Existing records are preserved and any duplicates in the file are
-skipped during import.
-During the import process the Admin page now shows a progress bar and log of actions.
-
-## Running Tests
-
-Before running tests make sure all dependencies are installed:
+### Running Tests
 
 ```bash
-cd backend && npm install
-cd ../frontend && pnpm install
+cd backend && npm install && npm test
+cd ../frontend && pnpm install && pnpm test
 ```
 
-Run the backend and frontend test suites with:
+### Scraper Utility
 
-```bash
-npm test      # from ./backend
-pnpm test     # from ./frontend
-```
-
-## Scraper Script
-
-The backend includes a small utility that can fetch track or car information
-from Wikipedia. Use it to quickly populate images and descriptions:
+Fetch game, track or car information from Wikipedia:
 
 ```bash
 node backend/scrapers/scrapeInfo.js "Monza" "Ferrari 488 GT3"
 ```
 
-The script outputs JSON containing the page title, short description and a
-thumbnail image URL for each term. Provide any number of Wikipedia page titles
-as arguments.
-
-The Admin interface includes a new **Info Search** page that uses this scraper.
-Admins can search Wikipedia for a game, track, layout or car and save the
-resulting title, description and thumbnail directly to the database.
+The Admin interface exposes this functionality through the **Info Search** page.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file
+for details.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,5 +4,5 @@ JWT_SECRET=your_jwt_secret
 PORT=5000
 UPLOAD_DIR=../frontend/public
 CONTENT_DIR=../frontend/public/content
-APP_VERSION=v0.1
+APP_VERSION=v1.1
 DB_VERSION=v1

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "racing-lap-tracker-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Backend API for Racing Lap Time Tracker",
   "main": "server.js",
   "scripts": {

--- a/backend/routes/version.js
+++ b/backend/routes/version.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 router.get('/', (req, res) => {
   res.json({
-    appVersion: process.env.APP_VERSION || 'v0.1',
+    appVersion: process.env.APP_VERSION || 'v1.1',
     dbVersion: process.env.DB_VERSION || 'v1',
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 "name": "racing-lap-tracker-frontend",
 "private": true,
-"version": "0.0.0",
+"version": "1.1.0",
 "type": "module",
   "scripts": {
     "dev": "yes | pnpm install && vite",

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
   mockedApi.getLayouts.mockResolvedValue([]);
   mockedApi.getCars.mockResolvedValue([]);
   mockedApi.getAdminUsers.mockResolvedValue([]);
-  mockedApi.getVersion.mockResolvedValue({ appVersion: 'v0.1', dbVersion: 'v1' });
+  mockedApi.getVersion.mockResolvedValue({ appVersion: 'v1.1', dbVersion: 'v1' });
 });
 
 test('renders admin heading', () => {


### PR DESCRIPTION
## Summary
- bump backend and frontend version numbers to v1.1
- update version environment variables and tests
- rewrite README with new instructions and features

## Testing
- `npm test --prefix backend`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68573a9718088321a68148a4f3b8eb60