### PR TITLE
Add database cleanup tools

### DIFF
--- a/backend/tests/adminRoutes.test.js
+++ b/backend/tests/adminRoutes.test.js
@@ -197,4 +197,24 @@ describe('Admin routes', () => {
       ['g1', 'c1']
     );
   });
+
+  it('clears all lap times', async () => {
+    db.query.mockResolvedValue({});
+    const res = await request(app).delete('/api/admin/lapTimes');
+    expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalledWith('DELETE FROM lap_times');
+  });
+
+  it('clears game data', async () => {
+    mockClient.query.mockResolvedValue({ rows: [] });
+
+    const res = await request(app).delete('/api/admin/games/g1/data');
+
+    expect(res.status).toBe(200);
+    expect(mockClient.query).toHaveBeenCalledWith('BEGIN');
+    expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM lap_times WHERE game_id=$1', ['g1']);
+    expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM game_cars WHERE game_id=$1', ['g1']);
+    expect(mockClient.query).toHaveBeenCalledWith('DELETE FROM game_tracks WHERE game_id=$1', ['g1']);
+    expect(mockClient.query).toHaveBeenLastCalledWith('COMMIT');
+  });
 });

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -76,6 +76,16 @@ export async function deleteCar(id: string): Promise<Car> {
   return res.data;
 }
 
+export async function clearLapTimes(): Promise<{ message: string }> {
+  const res = await apiClient.delete('/admin/lapTimes');
+  return res.data;
+}
+
+export async function clearGameData(id: string): Promise<{ message: string }> {
+  const res = await apiClient.delete(`/admin/games/${id}/data`);
+  return res.data;
+}
+
 export async function exportDatabase(): Promise<any> {
   const res = await apiClient.get('/admin/export');
   return res.data;

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -24,6 +24,8 @@ import {
   uploadFile,
   exportDatabase,
   importDatabase,
+  clearLapTimes,
+  clearGameData,
   getVersion,
   getAdminUsers,
   createUser,
@@ -77,6 +79,7 @@ const AdminPage: React.FC = () => {
   const [newIsAdmin, setNewIsAdmin] = useState(false);
   const [importFile, setImportFile] = useState<File | null>(null);
   const [importProgress, setImportProgress] = useState(0);
+  const [clearGameId, setClearGameId] = useState('');
   const [logs, setLogs] = useState<string[]>([]);
   const [activeSection, setActiveSection] = useState('dbEditor');
   const navClass = (key: string) =>
@@ -340,6 +343,28 @@ const AdminPage: React.FC = () => {
     setImportProgress(0);
   };
 
+  const handleClearLapTimes = async () => {
+    if (window.confirm('Delete ALL lap times? This cannot be undone.')) {
+      await clearLapTimes();
+      refreshGames();
+      refreshTracks();
+      refreshLayouts();
+      refreshCars();
+    }
+  };
+
+  const handleClearGame = async () => {
+    if (!clearGameId) return;
+    if (window.confirm('Remove data for this game? This cannot be undone.')) {
+      await clearGameData(clearGameId);
+      setClearGameId('');
+      refreshGames();
+      refreshTracks();
+      refreshLayouts();
+      refreshCars();
+    }
+  };
+
   return (
     <div className="container mx-auto py-6 flex">
       <aside className="w-56 pr-4 border-r space-y-6">
@@ -434,6 +459,33 @@ const AdminPage: React.FC = () => {
                 ))}
               </div>
             )}
+            <div className="mt-4 space-y-2">
+              <Button size="sm" variant="destructive" onClick={handleClearLapTimes}>
+                Clear All Lap Times
+              </Button>
+              <div className="flex items-center space-x-2">
+                <select
+                  className="border p-1"
+                  value={clearGameId}
+                  onChange={(e) => setClearGameId(e.target.value)}
+                >
+                  <option value="">Select Game</option>
+                  {games.map((g) => (
+                    <option key={g.id} value={g.id}>
+                      {g.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={handleClearGame}
+                  disabled={!clearGameId}
+                >
+                  Clear Game Data
+                </Button>
+              </div>
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
## Summary
- add admin endpoints to remove all lap times or purge a game's data
- expose new API helpers for clearing lap times or game data
- update admin page with buttons to use the new cleanup tools
- test new admin routes

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575ec5d6c88321a8a3b388820945d1