### PR TITLE
Fix image loading and destructive button style

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cn } from '../../utils';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'ghost';
+  variant?: 'default' | 'ghost' | 'destructive';
   size?: 'default' | 'sm';
   asChild?: boolean;
 }
@@ -20,6 +20,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           variant === 'default' &&
             'bg-primary text-primary-foreground hover:bg-primary/90',
           variant === 'ghost' && 'hover:bg-accent hover:text-accent-foreground',
+          variant === 'destructive' &&
+            'bg-destructive text-destructive-foreground hover:bg-destructive/90',
           size === 'default' && 'h-10 px-4 py-2',
           size === 'sm' && 'h-9 px-3',
           className

--- a/frontend/src/pages/CarDetailPage.tsx
+++ b/frontend/src/pages/CarDetailPage.tsx
@@ -59,16 +59,19 @@ const CarDetailPage: React.FC = () => {
           .then((txt) => {
             setPackDesc(txt);
             const exts = ['jpg', 'png', 'jpeg', 'webp'];
-            exts.reduce((p, ext) =>
-              p.catch(() =>
-                fetch(`${base}/car.${ext}`, { method: 'HEAD' }).then((r) =>
-                  r.ok ? `${base}/car.${ext}` : Promise.reject()
-                )
-              ),
-              Promise.reject()
-            )
-              .then((img) => setPackImage(img as string))
-              .catch(() => {});
+            (async () => {
+              for (const ext of exts) {
+                try {
+                  const r = await fetch(`${base}/car.${ext}`, { method: 'HEAD' });
+                  if (r.ok) {
+                    setPackImage(`${base}/car.${ext}`);
+                    return;
+                  }
+                } catch {
+                  // ignore and try next
+                }
+              }
+            })();
           })
           .catch(() => {});
       })

--- a/frontend/src/pages/TrackDetailPage.tsx
+++ b/frontend/src/pages/TrackDetailPage.tsx
@@ -60,16 +60,19 @@ const TrackDetailPage: React.FC = () => {
           .then((txt) => {
             setPackDesc(txt);
             const exts = ['jpg', 'png', 'jpeg', 'webp'];
-            exts.reduce((p, ext) =>
-              p.catch(() =>
-                fetch(`${base}/track.${ext}`, { method: 'HEAD' }).then((r) =>
-                  r.ok ? `${base}/track.${ext}` : Promise.reject()
-                )
-              ),
-              Promise.reject()
-            )
-              .then((img) => setPackImage(img as string))
-              .catch(() => {});
+            (async () => {
+              for (const ext of exts) {
+                try {
+                  const r = await fetch(`${base}/track.${ext}`, { method: 'HEAD' });
+                  if (r.ok) {
+                    setPackImage(`${base}/track.${ext}`);
+                    return;
+                  }
+                } catch {
+                  // ignore and try next
+                }
+              }
+            })();
           })
           .catch(() => {});
       })


### PR DESCRIPTION
## Summary
- support `destructive` variant on Button component
- stop using `reduce` for sequential image fetches on detail pages

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857dde28520832197c568d41f795ed9