### PR TITLE
Add GamePack scan button

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ variables include `DATABASE_URL`, `JWT_SECRET`, `UPLOAD_DIR`, `CONTENT_DIR` and
 
 Uploaded images are stored in `frontend/public/images` by default. Markdown
 content lives under `frontend/public/content` and is served from `/content`.
+Game and vehicle metadata can be placed under `frontend/public/GamePack`. Use
+the **Scan GamePack** button on the Admin page to import any `*.json` files
+found in these folders.
 
 ### Frontend
 

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -175,6 +175,17 @@ router.get('/images', auth, admin, async (req, res, next) => {
   }
 });
 
+// Scan GamePack directory for JSON files and import into the database
+const { scanGamePack } = require('../utils/scanGamePack');
+router.post('/scanGamePack', auth, admin, async (req, res, next) => {
+  try {
+    const summary = await scanGamePack();
+    res.json({ message: 'Scan completed', summary });
+  } catch (err) {
+    next(err);
+  }
+});
+
 router.get('/export', auth, admin, async (req, res, next) => {
   try {
     const tables = [

--- a/backend/utils/scanGamePack.js
+++ b/backend/utils/scanGamePack.js
@@ -1,0 +1,119 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+const gamePackDir = path.resolve(
+  process.env.GAMEPACK_DIR ||
+    path.join(__dirname, '..', '..', 'frontend', 'public', 'GamePack')
+);
+
+async function upsertGame(data) {
+  const res = await db.query(
+    'INSERT INTO games (name, image_url) VALUES ($1,$2) ON CONFLICT (name) DO UPDATE SET image_url=EXCLUDED.image_url RETURNING id',
+    [data.name, data.imageUrl || null]
+  );
+  return res.rows[0].id;
+}
+
+async function upsertTrack(gameId, data) {
+  const res = await db.query(
+    'INSERT INTO tracks (game_id, name, image_url) VALUES ($1,$2,$3) ON CONFLICT (game_id, name) DO UPDATE SET image_url=EXCLUDED.image_url RETURNING id',
+    [gameId, data.name, data.imageUrl || null]
+  );
+  return res.rows[0].id;
+}
+
+async function upsertLayout(trackId, data) {
+  const res = await db.query(
+    'INSERT INTO layouts (track_id, name, image_url) VALUES ($1,$2,$3) ON CONFLICT (track_id, name) DO UPDATE SET image_url=EXCLUDED.image_url RETURNING id',
+    [trackId, data.name, data.imageUrl || null]
+  );
+  const layoutId = res.rows[0].id;
+  const tl = await db.query(
+    'INSERT INTO track_layouts (track_id, layout_id) VALUES ($1,$2) ON CONFLICT (track_id, layout_id) DO UPDATE SET track_id=EXCLUDED.track_id RETURNING id',
+    [trackId, layoutId]
+  );
+  return tl.rows[0].id;
+}
+
+async function upsertCar(gameId, data) {
+  const res = await db.query(
+    'INSERT INTO cars (name, image_url) VALUES ($1,$2) ON CONFLICT (name) DO UPDATE SET image_url=EXCLUDED.image_url RETURNING id',
+    [data.name, data.imageUrl || null]
+  );
+  const carId = res.rows[0].id;
+  await db.query(
+    'INSERT INTO game_cars (game_id, car_id) VALUES ($1,$2) ON CONFLICT DO NOTHING',
+    [gameId, carId]
+  );
+  return carId;
+}
+
+function safeReadJSON(file) {
+  try {
+    const txt = fs.readFileSync(file, 'utf8');
+    return JSON.parse(txt);
+  } catch {
+    return null;
+  }
+}
+
+async function scanGamePack() {
+  const summary = { games: 0, tracks: 0, layouts: 0, cars: 0 };
+  if (!fs.existsSync(gamePackDir)) return summary;
+  const games = fs
+    .readdirSync(gamePackDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory());
+  for (const g of games) {
+    const gameDir = path.join(gamePackDir, g.name);
+    const gameJson = safeReadJSON(path.join(gameDir, 'game.json'));
+    if (!gameJson) continue;
+    const gameId = await upsertGame(gameJson);
+    summary.games += 1;
+    const tracksDir = path.join(gameDir, 'tracks');
+    if (fs.existsSync(tracksDir)) {
+      const tFolders = fs
+        .readdirSync(tracksDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory());
+      for (const t of tFolders) {
+        const tJson = safeReadJSON(path.join(tracksDir, t.name, 'track.json'));
+        if (!tJson) continue;
+        const trackId = await upsertTrack(gameId, tJson);
+        summary.tracks += 1;
+        const layoutsDir = path.join(tracksDir, t.name, 'layouts');
+        if (fs.existsSync(layoutsDir)) {
+          const lFolders = fs
+            .readdirSync(layoutsDir, { withFileTypes: true })
+            .filter((d) => d.isDirectory());
+          for (const l of lFolders) {
+            const lJson = safeReadJSON(
+              path.join(layoutsDir, l.name, 'layout.json')
+            );
+            if (!lJson) continue;
+            const tlId = await upsertLayout(trackId, lJson);
+            await db.query(
+              'INSERT INTO game_tracks (game_id, track_layout_id) VALUES ($1,$2) ON CONFLICT DO NOTHING',
+              [gameId, tlId]
+            );
+            summary.layouts += 1;
+          }
+        }
+      }
+    }
+    const carsDir = path.join(gameDir, 'cars');
+    if (fs.existsSync(carsDir)) {
+      const cFolders = fs
+        .readdirSync(carsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory());
+      for (const c of cFolders) {
+        const cJson = safeReadJSON(path.join(carsDir, c.name, 'car.json'));
+        if (!cJson) continue;
+        await upsertCar(gameId, cJson);
+        summary.cars += 1;
+      }
+    }
+  }
+  return summary;
+}
+
+module.exports = { scanGamePack };

--- a/docs/gamepack_json_examples.md
+++ b/docs/gamepack_json_examples.md
@@ -1,0 +1,38 @@
+# GamePack JSON Examples
+
+The admin scan feature reads `.json` files from `frontend/public/GamePack` to automatically import data.
+Each game directory should contain a `game.json` file and optional subfolders for cars, tracks and layouts.
+
+## game.json
+```json
+{
+  "name": "Example Racing Game",
+  "imageUrl": "/images/games/example.jpg"
+}
+```
+
+## track.json
+```json
+{
+  "name": "Monza",
+  "imageUrl": "/images/tracks/monza.jpg",
+  "description": "Fast circuit in Italy"
+}
+```
+
+## layout.json
+```json
+{
+  "name": "Full Course",
+  "imageUrl": "/images/layouts/monza_full.jpg"
+}
+```
+
+## car.json
+```json
+{
+  "name": "Chevrolet Chevette",
+  "imageUrl": "/images/cars/chevette.jpg",
+  "description": "Classic hatchback"
+}
+```

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -135,3 +135,8 @@ export async function searchImages(query: string) {
   const res = await apiClient.get('/admin/images', { params: { q: query } });
   return res.data as { images: string[] };
 }
+
+export async function scanGamePack() {
+  const res = await apiClient.post('/admin/scanGamePack');
+  return res.data as { message: string; summary: { games: number; tracks: number; layouts: number; cars: number } };
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -26,6 +26,7 @@ import {
   importDatabase,
   clearLapTimes,
   clearGameData,
+  scanGamePack,
   getVersion,
   getAdminUsers,
   createUser,
@@ -39,6 +40,7 @@ import { slugify, getImageUrl, cn } from '../utils';
 import EditableTable, { Column } from '../components/admin/EditableTable';
 import ProgressBar from '../components/admin/ProgressBar';
 import CollapsibleSection from '../components/admin/CollapsibleSection';
+import { toast } from 'sonner';
 
 const AdminPage: React.FC = () => {
   const [lapTimes, setLapTimes] = useState<LapTime[]>([]);
@@ -365,6 +367,22 @@ const AdminPage: React.FC = () => {
     }
   };
 
+  const handleScanGamePack = async () => {
+    toast.info('Scanning GamePack...');
+    try {
+      const res = await scanGamePack();
+      toast.success(
+        `Scan completed: ${res.summary.games} games, ${res.summary.tracks} tracks, ${res.summary.layouts} layouts, ${res.summary.cars} cars`
+      );
+      refreshGames();
+      refreshTracks();
+      refreshLayouts();
+      refreshCars();
+    } catch (err) {
+      toast.error('Scan failed');
+    }
+  };
+
   return (
     <div className="container mx-auto py-6 flex">
       <aside className="w-56 pr-4 border-r space-y-6">
@@ -450,6 +468,7 @@ const AdminPage: React.FC = () => {
               <Button size="sm" onClick={handleImportDb} disabled={!importFile}>
                 Import
               </Button>
+              <Button size="sm" onClick={handleScanGamePack}>Scan GamePack</Button>
             </div>
             {importProgress > 0 && <ProgressBar progress={importProgress} />}
             {logs.length > 0 && (


### PR DESCRIPTION
## Summary
- enable admins to scan `GamePack` directories from the admin page
- backend route and util to read JSON files from `frontend/public/GamePack`
- refresh data with toast notifications on scan completion
- document JSON examples and update README

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857e161fdd883219231fa9fc26d95ac