### PR TITLE
Fix GamePack scan in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ A `docker-compose.yml` file sets up PostgreSQL, the backend and the frontend:
 4. Visit `http://localhost:5173` to access the UI.
 
 Database data is stored in the `db-data` volume and images are written to
-`frontend/public/images`, which is mounted into both containers.
+`frontend/public/images`, which is mounted into both containers. The
+`frontend/public/GamePack` folder is also mounted so the backend can scan the
+example metadata files.
 
 ### Database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,11 @@ services:
       JWT_SECRET: supersecret
       PORT: 5000
       UPLOAD_DIR: ../frontend/public
-      CONTENT_DIR: ../frontend/public/conten
+      CONTENT_DIR: ../frontend/public/content
     volumes:
       - ./frontend/public/images:/usr/src/frontend/public/images
       - ./frontend/public/content:/usr/src/frontend/public/content
+      - ./frontend/public/GamePack:/usr/src/frontend/public/GamePack:ro
       - ./database:/usr/src/database:ro
     depends_on:
       db:
@@ -48,6 +49,7 @@ services:
     volumes:
       - ./frontend/public/images:/usr/src/app/dist/images
       - ./frontend/public/content:/usr/src/app/dist/content
+      - ./frontend/public/GamePack:/usr/src/app/dist/GamePack:ro
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- mount the `frontend/public/GamePack` folder for both backend and frontend containers
- fix typo in `CONTENT_DIR` path
- document the GamePack volume in Docker instructions

## Testing
- `npm test --silent` in `backend`
- `pnpm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857f7957bd88321b971acfeb75168ea