### PR TITLE
Fix slugify for accented characters

### DIFF
--- a/frontend/src/utils/slug.ts
+++ b/frontend/src/utils/slug.ts
@@ -1,5 +1,7 @@
 export function slugify(str: string): string {
   return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');


### PR DESCRIPTION
## Summary
- ensure slugify removes diacritics before replacing non-alphanumeric chars

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6857fde3f9a08321a71511eed1eb5d03