### PR TITLE
Fix type error in MarkdownRenderer

### DIFF
--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -8,12 +8,9 @@ interface Props {
 }
 
 const MarkdownRenderer: React.FC<Props> = ({ content, className }) => (
-  <ReactMarkdown
-    className={`prose prose-sm max-w-none ${className || ''}`.trim()}
-    remarkPlugins={[remarkGfm]}
-  >
-    {content}
-  </ReactMarkdown>
+  <div className={`prose prose-sm max-w-none ${className || ''}`.trim()}>
+    <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+  </div>
 );
 
 export default MarkdownRenderer;


### PR DESCRIPTION
## Summary
- wrap `ReactMarkdown` output in a div so the component accepts a `className`

## Testing
- `pnpm build`
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68587bab7bf08321ac7c1f7ca3714bc5