### PR TITLE
Add info components with Markdown support

### DIFF
--- a/frontend/__mocks__/rehype-raw.js
+++ b/frontend/__mocks__/rehype-raw.js
@@ -1,0 +1,1 @@
+module.exports = function() { return () => {}; };

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -11,7 +11,8 @@ module.exports = {
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
     '^react-markdown$': '<rootDir>/__mocks__/react-markdown.js',
     '^remark-gfm$': '<rootDir>/__mocks__/remark-gfm.js',
+    '^rehype-raw$': '<rootDir>/__mocks__/rehype-raw.js',
   },
-  transformIgnorePatterns: ['/node_modules/(?!.*react-markdown.*|.*remark-gfm.*)'],
+  transformIgnorePatterns: ['/node_modules/(?!.*react-markdown.*|.*remark-gfm.*|.*rehype-raw.*|.*hast-util-raw.*)'],
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.54.2",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
     "react-resizable-panels": "^2.1.7",
     "react-router-dom": "^6",
     "recharts": "^2.12.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       recharts:
         specifier: ^2.12.4
         version: 2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2701,11 +2704,26 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.0:
+    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -2716,6 +2734,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -3594,6 +3615,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@6.5.0:
+    resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -3757,6 +3781,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -4169,6 +4196,9 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
 
@@ -4224,6 +4254,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -6934,6 +6967,37 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.0
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -6954,9 +7018,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
 
   html-encoding-sniffer@3.0.0:
     dependencies:
@@ -6965,6 +7047,8 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -8226,6 +8310,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@6.5.0: {}
+
   property-information@7.1.0: {}
 
   proxy-from-env@1.1.0: {}
@@ -8404,6 +8490,12 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
 
   remark-gfm@4.0.1:
     dependencies:
@@ -8879,6 +8971,11 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.2:
     dependencies:
       '@types/unist': 3.0.3
@@ -8927,6 +9024,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@7.0.0: {}
 

--- a/frontend/src/components/CarInfo.tsx
+++ b/frontend/src/components/CarInfo.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import MarkdownRenderer from './MarkdownRenderer';
+import { slugify } from '../utils';
+
+interface CarInfoProps {
+  game: string;
+  car: string;
+  className?: string;
+  fallback?: string;
+}
+
+const CarInfo: React.FC<CarInfoProps> = ({ game, car, className, fallback }) => {
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    const path = `/GamePack/${slugify(game)}/cars/${slugify(car)}/info.md`;
+    fetch(path)
+      .then((res) => (res.ok ? res.text() : Promise.reject()))
+      .then((text) => setContent(text))
+      .catch(() => setContent(null));
+  }, [game, car]);
+
+  if (content === null) {
+    return fallback ? <p className={className}>{fallback}</p> : null;
+  }
+
+  return <MarkdownRenderer content={content} className={className} />;
+};
+
+export default CarInfo;

--- a/frontend/src/components/GameInfo.tsx
+++ b/frontend/src/components/GameInfo.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import MarkdownRenderer from './MarkdownRenderer';
+import { slugify } from '../utils';
+
+interface GameInfoProps {
+  game: string;
+  className?: string;
+  fallback?: string;
+}
+
+const GameInfo: React.FC<GameInfoProps> = ({ game, className, fallback }) => {
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    const path = `/GamePack/${slugify(game)}/info.md`;
+    fetch(path)
+      .then((res) => (res.ok ? res.text() : Promise.reject()))
+      .then((text) => setContent(text))
+      .catch(() => setContent(null));
+  }, [game]);
+
+  if (content === null) {
+    return fallback ? <p className={className}>{fallback}</p> : null;
+  }
+
+  return <MarkdownRenderer content={content} className={className} />;
+};
+
+export default GameInfo;

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 
 interface Props {
   content: string;
@@ -9,7 +10,9 @@ interface Props {
 
 const MarkdownRenderer: React.FC<Props> = ({ content, className }) => (
   <div className={`prose prose-sm max-w-none ${className || ''}`.trim()}>
-    <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>
+      {content}
+    </ReactMarkdown>
   </div>
 );
 

--- a/frontend/src/components/TrackInfo.tsx
+++ b/frontend/src/components/TrackInfo.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import MarkdownRenderer from './MarkdownRenderer';
+import { slugify } from '../utils';
+
+interface TrackInfoProps {
+  game: string;
+  track: string;
+  className?: string;
+  fallback?: string;
+}
+
+const TrackInfo: React.FC<TrackInfoProps> = ({ game, track, className, fallback }) => {
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    const path = `/GamePack/${slugify(game)}/tracks/${slugify(track)}/info.md`;
+    fetch(path)
+      .then((res) => (res.ok ? res.text() : Promise.reject()))
+      .then((text) => setContent(text))
+      .catch(() => setContent(null));
+  }, [game, track]);
+
+  if (content === null) {
+    return fallback ? <p className={className}>{fallback}</p> : null;
+  }
+
+  return <MarkdownRenderer content={content} className={className} />;
+};
+
+export default TrackInfo;


### PR DESCRIPTION
## Summary
- support raw HTML in MarkdownRenderer
- create GameInfo, CarInfo and TrackInfo components for info.md files
- add rehype-raw dependency and update Jest config

## Testing
- `cd backend && npm install && npm test`
- `cd ../frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6858899d0e48832186ec338b58febe73