### PR TITLE
Add support for legacy layout folders

### DIFF
--- a/docs/gamepack_json_examples.md
+++ b/docs/gamepack_json_examples.md
@@ -1,7 +1,13 @@
 # GamePack JSON Examples
 
 The admin scan feature reads `.json` files from `frontend/public/GamePack` to automatically import data.
-Each game directory should contain a `game.json` file and optional subfolders for cars, tracks and layouts.
+Each game directory should contain a `game.json` file and optional subfolders for cars and tracks.  
+Layouts can live under a dedicated `layouts` directory or directly inside the track folder:
+
+```
+GamePack/<game>/tracks/<track>/layouts/<layout>/layout.json
+GamePack/<game>/tracks/<track>/<layout>/layout.json  # legacy structure
+```
 
 ## game.json
 ```json


### PR DESCRIPTION
## Summary
- scan GamePack layout data from either `layouts/<layout>` or direct subdirs
- clarify layout folder options in the docs

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68591330cd448321b3990ccf7a44a8e3