### PR TITLE
Fix missing assists by seeding defaults

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,6 +25,7 @@ const versionRoutes = require('./routes/version');
 const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const { contentDir } = require('./utils/markdown');
 const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
+const { seedDefaultAssists } = require('./utils/seedDefaultAssists');
 const waitForDb = require('./utils/waitForDb');
 const errorHandler = require('./middleware/errorHandler');
 
@@ -76,6 +77,7 @@ if (process.env.NODE_ENV !== 'test') {
   (async () => {
     try {
       await waitForDb();
+      await seedDefaultAssists();
       if (seedSamples) {
         await seedSampleLapTimes();
       }

--- a/backend/utils/seedDefaultAssists.js
+++ b/backend/utils/seedDefaultAssists.js
@@ -1,0 +1,35 @@
+const db = require('./database');
+
+const defaultAssists = [
+  'Traction Control',
+  'ABS',
+  'Stability Control',
+  'Auto Clutch',
+  'Automatic Transmission',
+  'Launch Control',
+  'Brake Assist',
+  'Throttle Assist',
+  'Steering Assist',
+  'Racing Line',
+  'Suggested Gear Indicator',
+  'Braking Indicator',
+  'Cornering Guide',
+  'Ghosting / Collision Off',
+  'Tire Wear Off',
+  'Fuel Usage Off',
+  'Mechanical Failures Off',
+  'Damage Off',
+];
+
+async function seedDefaultAssists() {
+  const { rows } = await db.query('SELECT COUNT(*) FROM assists');
+  if (parseInt(rows[0].count, 10) > 0) return;
+
+  for (const name of defaultAssists) {
+    // eslint-disable-next-line no-await-in-loop
+    await db.query('INSERT INTO assists (name) VALUES ($1) ON CONFLICT DO NOTHING', [name]);
+  }
+  console.log('Inserted default assists');
+}
+
+module.exports = { seedDefaultAssists };


### PR DESCRIPTION
## Summary
- seed default assists at startup if none exist
- ensure sample lap time seeding still runs after assists seed

## Testing
- `npm test` in backend
- `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68592638d8248321b411db5c0bcc9a2f