### PR TITLE
Add layout metadata fields

### DIFF
--- a/backend/routes/layouts.js
+++ b/backend/routes/layouts.js
@@ -11,14 +11,42 @@ router.get('/', async (req, res, next) => {
     let result;
     if (trackId) {
       result = await db.query(
-        `SELECT l.id, l.track_id AS "trackId", l.name, l.image_url AS "imageUrl", tl.id AS "trackLayoutId"
+        `SELECT l.id, l.track_id AS "trackId", l.name, l.image_url AS "imageUrl", tl.id AS "trackLayoutId",
+                tl.pit_speed_limit_high_kph AS "pitSpeedLimitHighKPH",
+                tl.max_ai_participants AS "maxAIParticipants",
+                tl.race_date_year AS "raceDateYear",
+                tl.race_date_month AS "raceDateMonth",
+                tl.race_date_day AS "raceDateDay",
+                tl.track_surface AS "trackSurface",
+                tl.track_type AS "trackType",
+                tl.track_grade_filter AS "trackGradeFilter",
+                tl.number_of_turns AS "numberOfTurns",
+                tl.track_time_zone AS "trackTimeZone",
+                tl.track_altitude AS "trackAltitude",
+                tl.length AS "length",
+                tl.dlc_id AS "dlcId",
+                tl.location AS "location"
          FROM layouts l JOIN track_layouts tl ON tl.layout_id = l.id
          WHERE l.track_id = $1 ORDER BY l.name`,
         [trackId]
       );
     } else {
       result = await db.query(
-        `SELECT l.id, l.track_id AS "trackId", l.name, l.image_url AS "imageUrl", tl.id AS "trackLayoutId"
+        `SELECT l.id, l.track_id AS "trackId", l.name, l.image_url AS "imageUrl", tl.id AS "trackLayoutId",
+                tl.pit_speed_limit_high_kph AS "pitSpeedLimitHighKPH",
+                tl.max_ai_participants AS "maxAIParticipants",
+                tl.race_date_year AS "raceDateYear",
+                tl.race_date_month AS "raceDateMonth",
+                tl.race_date_day AS "raceDateDay",
+                tl.track_surface AS "trackSurface",
+                tl.track_type AS "trackType",
+                tl.track_grade_filter AS "trackGradeFilter",
+                tl.number_of_turns AS "numberOfTurns",
+                tl.track_time_zone AS "trackTimeZone",
+                tl.track_altitude AS "trackAltitude",
+                tl.length AS "length",
+                tl.dlc_id AS "dlcId",
+                tl.location AS "location"
          FROM layouts l JOIN track_layouts tl ON tl.layout_id = l.id
          ORDER BY l.name`
       );
@@ -37,13 +65,45 @@ router.post(
     body('trackId').notEmpty(),
     body('name').trim().escape().notEmpty(),
     body('imageUrl').optional().trim(),
+    body('pitSpeedLimitHighKPH').optional(),
+    body('maxAIParticipants').optional(),
+    body('raceDateYear').optional(),
+    body('raceDateMonth').optional(),
+    body('raceDateDay').optional(),
+    body('trackSurface').optional(),
+    body('trackType').optional(),
+    body('trackGradeFilter').optional(),
+    body('numberOfTurns').optional(),
+    body('trackTimeZone').optional(),
+    body('trackAltitude').optional(),
+    body('length').optional(),
+    body('dlcId').optional(),
+    body('location').optional(),
   ],
   async (req, res, next) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const { trackId, name, imageUrl } = req.body;
+    const {
+      trackId,
+      name,
+      imageUrl,
+      pitSpeedLimitHighKPH,
+      maxAIParticipants,
+      raceDateYear,
+      raceDateMonth,
+      raceDateDay,
+      trackSurface,
+      trackType,
+      trackGradeFilter,
+      numberOfTurns,
+      trackTimeZone,
+      trackAltitude,
+      length,
+      dlcId,
+      location,
+    } = req.body;
     try {
       const result = await db.query(
         'INSERT INTO layouts (track_id, name, image_url) VALUES ($1,$2,$3) RETURNING id, track_id AS "trackId", name, image_url AS "imageUrl"',
@@ -51,8 +111,44 @@ router.post(
       );
       const layout = result.rows[0];
       const tl = await db.query(
-        'INSERT INTO track_layouts (track_id, layout_id) VALUES ($1,$2) RETURNING id',
-        [trackId, layout.id]
+        `INSERT INTO track_layouts (
+          track_id,
+          layout_id,
+          pit_speed_limit_high_kph,
+          max_ai_participants,
+          race_date_year,
+          race_date_month,
+          race_date_day,
+          track_surface,
+          track_type,
+          track_grade_filter,
+          number_of_turns,
+          track_time_zone,
+          track_altitude,
+          length,
+          dlc_id,
+          location
+        ) VALUES (
+          $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16
+        ) RETURNING id`,
+        [
+          trackId,
+          layout.id,
+          pitSpeedLimitHighKPH || null,
+          maxAIParticipants || null,
+          raceDateYear || null,
+          raceDateMonth || null,
+          raceDateDay || null,
+          trackSurface || null,
+          trackType || null,
+          trackGradeFilter || null,
+          numberOfTurns || null,
+          trackTimeZone || null,
+          trackAltitude || null,
+          length || null,
+          dlcId || null,
+          location || null,
+        ]
       );
       res.status(201).json({ ...layout, trackLayoutId: tl.rows[0].id });
     } catch (err) {
@@ -69,6 +165,20 @@ router.put(
     body('trackId').notEmpty(),
     body('name').trim().escape().notEmpty(),
     body('imageUrl').optional().trim(),
+    body('pitSpeedLimitHighKPH').optional(),
+    body('maxAIParticipants').optional(),
+    body('raceDateYear').optional(),
+    body('raceDateMonth').optional(),
+    body('raceDateDay').optional(),
+    body('trackSurface').optional(),
+    body('trackType').optional(),
+    body('trackGradeFilter').optional(),
+    body('numberOfTurns').optional(),
+    body('trackTimeZone').optional(),
+    body('trackAltitude').optional(),
+    body('length').optional(),
+    body('dlcId').optional(),
+    body('location').optional(),
   ],
   async (req, res, next) => {
     const { id } = req.params;
@@ -76,7 +186,25 @@ router.put(
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const { trackId, name, imageUrl } = req.body;
+    const {
+      trackId,
+      name,
+      imageUrl,
+      pitSpeedLimitHighKPH,
+      maxAIParticipants,
+      raceDateYear,
+      raceDateMonth,
+      raceDateDay,
+      trackSurface,
+      trackType,
+      trackGradeFilter,
+      numberOfTurns,
+      trackTimeZone,
+      trackAltitude,
+      length,
+      dlcId,
+      location,
+    } = req.body;
     try {
       const result = await db.query(
         'UPDATE layouts SET track_id=$1, name=$2, image_url=$3 WHERE id=$4 RETURNING id, track_id AS "trackId", name, image_url AS "imageUrl"',
@@ -87,8 +215,41 @@ router.put(
       }
       const layout = result.rows[0];
       const tl = await db.query(
-        'UPDATE track_layouts SET track_id=$1 WHERE layout_id=$2 RETURNING id',
-        [trackId, id]
+        `UPDATE track_layouts SET
+          track_id=$1,
+          pit_speed_limit_high_kph=$2,
+          max_ai_participants=$3,
+          race_date_year=$4,
+          race_date_month=$5,
+          race_date_day=$6,
+          track_surface=$7,
+          track_type=$8,
+          track_grade_filter=$9,
+          number_of_turns=$10,
+          track_time_zone=$11,
+          track_altitude=$12,
+          length=$13,
+          dlc_id=$14,
+          location=$15
+        WHERE layout_id=$16 RETURNING id`,
+        [
+          trackId,
+          pitSpeedLimitHighKPH || null,
+          maxAIParticipants || null,
+          raceDateYear || null,
+          raceDateMonth || null,
+          raceDateDay || null,
+          trackSurface || null,
+          trackType || null,
+          trackGradeFilter || null,
+          numberOfTurns || null,
+          trackTimeZone || null,
+          trackAltitude || null,
+          length || null,
+          dlcId || null,
+          location || null,
+          id,
+        ]
       );
       res.json({ ...layout, trackLayoutId: tl.rows[0].id });
     } catch (err) {

--- a/backend/utils/scanGamePack.js
+++ b/backend/utils/scanGamePack.js
@@ -30,8 +30,45 @@ async function upsertLayout(trackId, data) {
   );
   const layoutId = res.rows[0].id;
   const tl = await db.query(
-    'INSERT INTO track_layouts (track_id, layout_id) VALUES ($1,$2) ON CONFLICT (track_id, layout_id) DO UPDATE SET track_id=EXCLUDED.track_id RETURNING id',
-    [trackId, layoutId]
+    `INSERT INTO track_layouts (
+      track_id,
+      layout_id,
+      pit_speed_limit_high_kph,
+      max_ai_participants,
+      race_date_year,
+      race_date_month,
+      race_date_day,
+      track_surface,
+      track_type,
+      track_grade_filter,
+      number_of_turns,
+      track_time_zone,
+      track_altitude,
+      length,
+      dlc_id,
+      location
+    ) VALUES (
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16
+    ) ON CONFLICT (track_id, layout_id)
+      DO UPDATE SET track_id=EXCLUDED.track_id RETURNING id`,
+    [
+      trackId,
+      layoutId,
+      data.pitSpeedLimitHighKPH || null,
+      data.maxAIParticipants || null,
+      data.raceDateYear || null,
+      data.raceDateMonth || null,
+      data.raceDateDay || null,
+      data.trackSurface || null,
+      data.trackType || null,
+      data.trackGradeFilter || null,
+      data.numberOfTurns || null,
+      data.trackTimeZone || null,
+      data.trackAltitude || null,
+      data.length || null,
+      data.dlcId || null,
+      data.location || null,
+    ]
   );
   return tl.rows[0].id;
 }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -57,6 +57,20 @@ CREATE TABLE track_layouts (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     track_id UUID NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     layout_id UUID NOT NULL REFERENCES layouts(id) ON DELETE CASCADE,
+    pit_speed_limit_high_kph INTEGER,
+    max_ai_participants INTEGER,
+    race_date_year INTEGER,
+    race_date_month INTEGER,
+    race_date_day INTEGER,
+    track_surface TEXT,
+    track_type TEXT,
+    track_grade_filter TEXT,
+    number_of_turns INTEGER,
+    track_time_zone TEXT,
+    track_altitude TEXT,
+    length TEXT,
+    dlc_id TEXT,
+    location TEXT,
     UNIQUE(track_id, layout_id)
 );
 

--- a/docs/gamepack_json_examples.md
+++ b/docs/gamepack_json_examples.md
@@ -30,7 +30,21 @@ GamePack/<game>/tracks/<track>/<layout>/layout.json  # legacy structure
 ```json
 {
   "name": "Full Course",
-  "imageUrl": "/images/layouts/monza_full.jpg"
+  "imageUrl": "/images/layouts/monza_full.jpg",
+  "pitSpeedLimitHighKPH": 80,
+  "maxAIParticipants": 32,
+  "raceDateYear": 2024,
+  "raceDateMonth": 6,
+  "raceDateDay": 1,
+  "trackSurface": "Asphalt",
+  "trackType": "Permanent Circuit",
+  "trackGradeFilter": "Grade 1",
+  "numberOfTurns": 15,
+  "trackTimeZone": "Europe/Rome",
+  "trackAltitude": "112m",
+  "length": "5.79 km",
+  "dlcId": "pack1",
+  "location": "Monza, Italy"
 }
 ```
 

--- a/frontend/src/pages/TrackDetailPage.tsx
+++ b/frontend/src/pages/TrackDetailPage.tsx
@@ -213,13 +213,80 @@ const TrackDetailPage: React.FC = () => {
       {layouts.map((layout) => (
         <div key={layout.id} className="space-y-2">
           <h2 className="text-2xl font-semibold">{layout.name}</h2>
-          {layout.imageUrl && (
-            <img
-              src={getImageUrl(layout.imageUrl)}
-              alt={layout.name}
-              className="max-w-lg rounded mb-2"
-            />
-          )}
+          <div className="flex flex-col md:flex-row md:space-x-4">
+            {layout.imageUrl && (
+              <img
+                src={getImageUrl(layout.imageUrl)}
+                alt={layout.name}
+                className="max-w-lg rounded mb-2 md:mb-0"
+              />
+            )}
+            <div className="text-sm space-y-1 md:w-80">
+              {layout.location && (
+                <p>
+                  <strong>Location:</strong> {layout.location}
+                </p>
+              )}
+              {layout.pitSpeedLimitHighKPH && (
+                <p>
+                  <strong>Pit Speed Limit:</strong> {layout.pitSpeedLimitHighKPH} kph
+                </p>
+              )}
+              {layout.maxAIParticipants && (
+                <p>
+                  <strong>Max AI participants:</strong> {layout.maxAIParticipants}
+                </p>
+              )}
+              {layout.numberOfTurns && (
+                <p>
+                  <strong>Number Of Turns:</strong> {layout.numberOfTurns}
+                </p>
+              )}
+              {layout.trackSurface && (
+                <p>
+                  <strong>Track Surface:</strong> {layout.trackSurface}
+                </p>
+              )}
+              {layout.trackType && (
+                <p>
+                  <strong>Track Type:</strong> {layout.trackType}
+                </p>
+              )}
+              {(layout.raceDateYear || layout.raceDateMonth || layout.raceDateDay) && (
+                <p>
+                  <strong>Race Date:</strong>{' '}
+                  {[layout.raceDateYear, layout.raceDateMonth, layout.raceDateDay]
+                    .filter(Boolean)
+                    .join('-')}
+                </p>
+              )}
+              {layout.trackGradeFilter && (
+                <p>
+                  <strong>Track Grade:</strong> {layout.trackGradeFilter}
+                </p>
+              )}
+              {layout.trackTimeZone && (
+                <p>
+                  <strong>Time Zone:</strong> {layout.trackTimeZone}
+                </p>
+              )}
+              {layout.trackAltitude && (
+                <p>
+                  <strong>Altitude:</strong> {layout.trackAltitude}
+                </p>
+              )}
+              {layout.length && (
+                <p>
+                  <strong>Length:</strong> {layout.length}
+                </p>
+              )}
+              {layout.dlcId && (
+                <p>
+                  <strong>DLC ID:</strong> {layout.dlcId}
+                </p>
+              )}
+            </div>
+          </div>
           {records[layout.id] && records[layout.id].length > 0 ? (
             <div className="overflow-x-auto">
               <table className="min-w-full text-sm border">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,20 @@ export interface Layout {
   name: string;
   imageUrl?: string | null;
   trackLayoutId?: string;
+  pitSpeedLimitHighKPH?: number | null;
+  maxAIParticipants?: number | null;
+  raceDateYear?: number | null;
+  raceDateMonth?: number | null;
+  raceDateDay?: number | null;
+  trackSurface?: string | null;
+  trackType?: string | null;
+  trackGradeFilter?: string | null;
+  numberOfTurns?: number | null;
+  trackTimeZone?: string | null;
+  trackAltitude?: string | null;
+  length?: string | null;
+  dlcId?: string | null;
+  location?: string | null;
 }
 
 export interface Car {


### PR DESCRIPTION
## Summary
- extend schema with track layout metadata columns
- document new layout.json fields
- import layout metadata in GamePack scanner
- expose metadata via layout routes
- update types and TrackDetailPage UI to show details

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68592b34cbdc8321bd99612ca15eb49f