### PR TITLE
Add layout metadata migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ psql -U <user> -d <database> -f database/schema.sql
 psql -U <user> -d <database> -f database/seed_data.sql
 # Optionally load the sample game and track data
 # psql -U <user> -d <database> -f database/sample_seed_data.sql.disabled
+# If upgrading from an older version run the layout metadata migration
+# psql -U <user> -d <database> -f database/migrations/2025-06-add-layout-metadata.sql
 ```
 
 Sample lap times from `database/sample_lap_times.json` are loaded on first start

--- a/database/migrations/2025-06-add-layout-metadata.sql
+++ b/database/migrations/2025-06-add-layout-metadata.sql
@@ -1,0 +1,15 @@
+-- Add layout metadata columns to track_layouts
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS pit_speed_limit_high_kph INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS max_ai_participants INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS race_date_year INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS race_date_month INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS race_date_day INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS track_surface TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS track_type TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS track_grade_filter TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS number_of_turns INTEGER;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS track_time_zone TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS track_altitude TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS length TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS dlc_id TEXT;
+ALTER TABLE track_layouts ADD COLUMN IF NOT EXISTS location TEXT;


### PR DESCRIPTION
## Summary
- add migration script to add layout metadata columns
- document how to run the migration in README

## Testing
- `npm test` in backend
- `pnpm test` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68593c8b5fdc8321bc884a9f51b67f25