### PR TITLE
Add GameDetail page and cleanup images

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import AdminPage from './pages/AdminPage';
 import InfoSearchPage from './pages/InfoSearchPage';
 import TrackDetailPage from './pages/TrackDetailPage';
 import CarDetailPage from './pages/CarDetailPage';
+import GameDetailPage from './pages/GameDetailPage';
 import InfoPage from './pages/InfoPage';
 import { useLocation } from 'react-router-dom';
 import './App.css';
@@ -56,6 +57,7 @@ function App() {
                   <Route path="/lap-times" element={<LapTimesPage />} />
                   <Route path="/track/:id" element={<TrackDetailPage />} />
                   <Route path="/car/:id" element={<CarDetailPage />} />
+                  <Route path="/game/:id" element={<GameDetailPage />} />
                   <Route path="/info/*" element={<InfoRoute />} />
                   <Route
                     path="/submit"

--- a/frontend/src/pages/GameDetailPage.test.tsx
+++ b/frontend/src/pages/GameDetailPage.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mockedApi = {
+  getGames: jest.fn(),
+  getLapTimes: jest.fn(),
+  getWorldRecords: jest.fn(),
+};
+
+jest.mock('../api', () => mockedApi);
+
+import GameDetailPage from './GameDetailPage';
+import { useAuth } from '../contexts/AuthContext';
+
+jest.mock('../contexts/AuthContext', () => ({ useAuth: jest.fn() }));
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+describe('GameDetailPage', () => {
+  beforeEach(() => {
+    mockedUseAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
+    mockedApi.getGames.mockResolvedValue([{ id: 'g1', name: 'Game', imageUrl: '' }]);
+    mockedApi.getLapTimes.mockResolvedValue([]);
+    mockedApi.getWorldRecords.mockResolvedValue([]);
+  });
+
+  it('renders game name', async () => {
+    render(
+      <MemoryRouter initialEntries={["/game/g1"]}>
+        <Routes>
+          <Route path="/game/:id" element={<GameDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('heading', { name: 'Game' })).toBeInTheDocument();
+  });
+
+  it('shows edit button for admins', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: '1', username: 'admin', email: 'a@b.c', isAdmin: true },
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/game/g1"]}>
+        <Routes>
+          <Route path="/game/:id" element={<GameDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(await screen.findByRole('button', { name: /edit/i })).toBeInTheDocument();
+  });
+
+  it('hides edit button for non-admins', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: '1', username: 'user', email: 'u@b.c', isAdmin: false },
+      isLoading: false,
+      login: jest.fn(),
+      register: jest.fn(),
+      logout: jest.fn(),
+      refreshUser: jest.fn(),
+    });
+    render(
+      <MemoryRouter initialEntries={["/game/g1"]}>
+        <Routes>
+          <Route path="/game/:id" element={<GameDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
+  });
+});

--- a/frontend/src/pages/TrackDetailPage.tsx
+++ b/frontend/src/pages/TrackDetailPage.tsx
@@ -23,7 +23,6 @@ const TrackDetailPage: React.FC = () => {
   const [description, setDescription] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [packDesc, setPackDesc] = useState<string | null>(null);
-  const [packImage, setPackImage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -49,7 +48,6 @@ const TrackDetailPage: React.FC = () => {
   useEffect(() => {
     if (!track) return;
     setPackDesc(null);
-    setPackImage(null);
     getGames()
       .then((games) => {
         const g = games.find((gm) => gm.id === track.gameId);
@@ -61,18 +59,6 @@ const TrackDetailPage: React.FC = () => {
             if (!res.ok) throw new Error('missing');
             const txt = await res.text();
             setPackDesc(txt);
-            const exts = ['jpg', 'png', 'jpeg', 'webp'];
-            for (const ext of exts) {
-              try {
-                const r = await fetch(`${p}/track.${ext}`, { method: 'HEAD' });
-                if (r.ok) {
-                  setPackImage(`${p}/track.${ext}`);
-                  return;
-                }
-              } catch {
-                // ignore and try next
-              }
-            }
           } catch {
             return false;
           }
@@ -147,13 +133,6 @@ const TrackDetailPage: React.FC = () => {
     <div className="container mx-auto py-6 space-y-6">
       <div className="text-center space-y-2">
         <h1 className="text-3xl font-bold">{track.name}</h1>
-        {(packImage || track.imageUrl) && (
-          <img
-            src={packImage || getImageUrl(track.imageUrl)}
-            alt={track.name}
-            className="mx-auto max-w-lg rounded"
-          />
-        )}
         {packDesc && !editing ? (
           <MarkdownRenderer content={packDesc} className="text-muted-foreground" />
         ) : track.description && !editing ? (


### PR DESCRIPTION
## Summary
- remove banner images from car and track detail pages
- add new GameDetail page showing laps per game
- route `/game/:id` to the new page
- test GameDetail page

## Testing
- `pnpm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685a0c9eee5c8321aa681b8411b15c9a