### PR TITLE
Add Showcase search page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ProfilePage from './pages/ProfilePage';
 import LapTimesPage from './pages/LapTimesPage';
+import ShowcasePage from './pages/ShowcasePage';
 import SubmitLapTimePage from './pages/SubmitLapTimePage';
 import AdminPage from './pages/AdminPage';
 import InfoSearchPage from './pages/InfoSearchPage';
@@ -55,6 +56,7 @@ function App() {
                 <Route path="/" element={<Layout />}>
                   <Route index element={<HomePage />} />
                   <Route path="/lap-times" element={<LapTimesPage />} />
+                  <Route path="/showcase" element={<ShowcasePage />} />
                   <Route path="/track/:id" element={<TrackDetailPage />} />
                   <Route path="/car/:id" element={<CarDetailPage />} />
                   <Route path="/game/:id" element={<GameDetailPage />} />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -40,6 +40,7 @@ const Header: React.FC = () => {
   const navItems = [
     { to: '/', label: 'Home', icon: Timer },
     { to: '/lap-times', label: 'Lap Times', icon: Timer },
+    { to: '/showcase', label: 'Showcase', icon: Search },
   ];
   const userNavItems = [
     { to: '/submit', label: 'Submit Lap', icon: PlusCircle },

--- a/frontend/src/pages/ShowcasePage.test.tsx
+++ b/frontend/src/pages/ShowcasePage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+
+const mockedApi = {
+  getGames: jest.fn().mockResolvedValue([]),
+  getTracks: jest.fn().mockResolvedValue([]),
+  getCars: jest.fn().mockResolvedValue([]),
+};
+
+jest.mock('../api', () => mockedApi);
+
+import ShowcasePage from './ShowcasePage';
+
+it('renders heading', () => {
+  render(<ShowcasePage />);
+  expect(screen.getByText(/Showcase/i)).toBeInTheDocument();
+});

--- a/frontend/src/pages/ShowcasePage.tsx
+++ b/frontend/src/pages/ShowcasePage.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { getGames, getTracks, getCars } from '../api';
+import { Game, Track, Car } from '../types';
+import { getImageUrl } from '../utils';
+
+const ShowcasePage: React.FC = () => {
+  const [games, setGames] = useState<Game[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
+  const [cars, setCars] = useState<Car[]>([]);
+  const [search, setSearch] = useState('');
+  const [gameFilter, setGameFilter] = useState('');
+
+  useEffect(() => {
+    getGames().then(setGames).catch(() => {});
+    getTracks().then(setTracks).catch(() => {});
+    getCars().then(setCars).catch(() => {});
+  }, []);
+
+  const searchLower = search.toLowerCase();
+  const filteredGames = games.filter((g) =>
+    g.name.toLowerCase().includes(searchLower)
+  );
+  const filteredTracks = tracks.filter(
+    (t) =>
+      (!gameFilter || t.gameId === gameFilter) &&
+      t.name.toLowerCase().includes(searchLower)
+  );
+  const filteredCars = cars.filter(
+    (c) =>
+      (!gameFilter || c.gameId === gameFilter) &&
+      c.name.toLowerCase().includes(searchLower)
+  );
+
+  return (
+    <div className="container mx-auto py-6 space-y-8">
+      <h1 className="text-3xl font-bold text-center">Showcase</h1>
+      <div className="flex flex-col md:flex-row md:items-end gap-4">
+        <input
+          type="text"
+          placeholder="Search..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full md:w-64 rounded border px-3 py-2"
+        />
+        <select
+          value={gameFilter}
+          onChange={(e) => setGameFilter(e.target.value)}
+          className="w-full md:w-64 rounded border px-3 py-2"
+        >
+          <option value="">All games</option>
+          {games.map((g) => (
+            <option key={g.id} value={g.id}>
+              {g.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Games</h2>
+        <div className="grid gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filteredGames.map((g) => (
+            <Link
+              key={g.id}
+              to={`/game/${g.id}`}
+              className="border rounded hover:shadow bg-card"
+            >
+              {g.imageUrl && (
+                <img
+                  src={getImageUrl(g.imageUrl)}
+                  alt={g.name}
+                  className="w-full h-32 object-cover rounded-t"
+                />
+              )}
+              <div className="p-2">
+                <h3 className="font-semibold">{g.name}</h3>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Tracks</h2>
+        <div className="grid gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filteredTracks.map((t) => (
+            <Link
+              key={t.id}
+              to={`/track/${t.id}`}
+              className="border rounded hover:shadow bg-card"
+            >
+              {t.imageUrl && (
+                <img
+                  src={getImageUrl(t.imageUrl)}
+                  alt={t.name}
+                  className="w-full h-32 object-cover rounded-t"
+                />
+              )}
+              <div className="p-2">
+                <h3 className="font-semibold">{t.name}</h3>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Cars</h2>
+        <div className="grid gap-4 grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filteredCars.map((c) => (
+            <Link
+              key={c.id}
+              to={`/car/${c.id}`}
+              className="border rounded hover:shadow bg-card"
+            >
+              {c.imageUrl && (
+                <img
+                  src={getImageUrl(c.imageUrl)}
+                  alt={c.name}
+                  className="w-full h-32 object-cover rounded-t"
+                />
+              )}
+              <div className="p-2">
+                <h3 className="font-semibold">{c.name}</h3>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default ShowcasePage;


### PR DESCRIPTION
## Summary
- add a Showcase page for browsing games, tracks and cars
- link Showcase from the top navigation
- expose the Showcase route in `App.tsx`
- test new Showcase page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685a0f9b963083218f92d5033e36261c