### PR TITLE
Add automatic DB migration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ psql -U <user> -d <database> -f database/seed_data.sql
 # psql -U <user> -d <database> -f database/migrations/2025-07-add-car-metadata.sql
 # If upgrading from an older version run the track metadata migration
 # psql -U <user> -d <database> -f database/migrations/2025-08-add-track-metadata.sql
+# Or run all migrations automatically
+# npm run migrate --prefix backend
 ```
 
 Sample lap times from `database/sample_lap_times.json` are loaded on first start
@@ -143,7 +145,8 @@ The Admin interface exposes this functionality through the **Info Search** page.
   from importing.
 - If the GamePack scan fails after upgrading, run the latest migrations
   (`2025-06-add-layout-metadata.sql` and `2025-08-add-track-metadata.sql`) to
-  create any missing columns.
+  create any missing columns. You can run them manually or execute
+  `npm run migrate --prefix backend` to apply them automatically.
 - Uploaded images are stored inside `frontend/public/images`. Ensure this
   directory exists and is writable by the backend.
 - Use `npm run dev` for automatic reload during development; `npm start` runs the

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "migrate": "node utils/runMigrations.js",
     "pretest": "test -d node_modules || npm install",
     "test": "jest"
   },

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,6 +26,7 @@ const { router: uploadRoutes, uploadDir } = require('./routes/uploads');
 const { contentDir } = require('./utils/markdown');
 const { seedSampleLapTimes } = require('./utils/seedSampleLapTimes');
 const { seedDefaultAssists } = require('./utils/seedDefaultAssists');
+const runMigrations = require('./utils/runMigrations');
 const waitForDb = require('./utils/waitForDb');
 const errorHandler = require('./middleware/errorHandler');
 
@@ -77,6 +78,7 @@ if (process.env.NODE_ENV !== 'test') {
   (async () => {
     try {
       await waitForDb();
+      await runMigrations();
       await seedDefaultAssists();
       if (seedSamples) {
         await seedSampleLapTimes();

--- a/backend/utils/runMigrations.js
+++ b/backend/utils/runMigrations.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+
+async function runMigrations() {
+  const migrationsDir = path.join(__dirname, '..', '..', 'database', 'migrations');
+  if (!fs.existsSync(migrationsDir)) {
+    console.log('No migrations directory found');
+    return;
+  }
+  const files = fs.readdirSync(migrationsDir)
+    .filter((f) => f.endsWith('.sql'))
+    .sort();
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await db.query(sql);
+      console.log(`Ran migration ${file}`);
+    } catch (err) {
+      console.error(`Failed to run migration ${file}`);
+      throw err;
+    }
+  }
+}
+
+if (require.main === module) {
+  runMigrations()
+    .then(() => {
+      console.log('Migrations complete');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Migration failed', err);
+      process.exit(1);
+    });
+}
+
+module.exports = runMigrations;


### PR DESCRIPTION
## Summary
- add `runMigrations` helper and call it during server start
- expose new `npm run migrate` script
- document the migration helper in README

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_685aa0445c288321beb83bad7cf8175d