### PR TITLE
Add sample data generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ include:
 * `CONTENT_DIR` – Markdown content directory
 * `APP_VERSION` and `DB_VERSION` – displayed in the API `/api/version` endpoint
 * `SEED_SAMPLE_LAPTIMES` – load sample data on first start
+* `ENABLE_SAMPLE_DATA` – allow generating demo users and lap times from the Admin page
 
 The frontend uses a single variable `VITE_API_URL` to point at the backend API.
 
@@ -115,6 +116,7 @@ psql -U <user> -d <database> -f database/seed_data.sql
 
 Sample lap times from `database/sample_lap_times.json` are loaded on first start
 when the table is empty. Set `SEED_SAMPLE_LAPTIMES=false` to skip loading these records.
+Set `ENABLE_SAMPLE_DATA=true` to add a "Generate Sample Data" button on the Admin page.
 
 ### Running Tests
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,3 +7,4 @@ CONTENT_DIR=../frontend/public/content
 APP_VERSION=v1.1
 DB_VERSION=v1
 SEED_SAMPLE_LAPTIMES=true
+ENABLE_SAMPLE_DATA=false

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -81,6 +81,20 @@ router.delete('/lapTimes', auth, admin, async (req, res, next) => {
   }
 });
 
+// Generate demo users and lap times
+const { generateSampleData } = require('../utils/generateSampleData');
+router.post('/generateSampleData', auth, admin, async (req, res, next) => {
+  if (process.env.ENABLE_SAMPLE_DATA !== 'true') {
+    return res.status(404).json({ message: 'Not enabled' });
+  }
+  try {
+    await generateSampleData();
+    res.json({ message: 'Sample data generated' });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // Clear data related to a specific game
 router.delete('/games/:id/data', auth, admin, async (req, res, next) => {
   const { id } = req.params;

--- a/backend/routes/version.js
+++ b/backend/routes/version.js
@@ -6,6 +6,7 @@ router.get('/', (req, res) => {
   res.json({
     appVersion: process.env.APP_VERSION || 'v1.1',
     dbVersion: process.env.DB_VERSION || 'v1',
+    sampleDataEnabled: process.env.ENABLE_SAMPLE_DATA === 'true',
   });
 });
 

--- a/backend/utils/generateSampleData.js
+++ b/backend/utils/generateSampleData.js
@@ -1,0 +1,79 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./database');
+const { seedDefaultAssists } = require('./seedDefaultAssists');
+
+const sampleUsers = [
+  'SpeedySam',
+  'TurboTom',
+  'RapidRita',
+  'QuickQuinn',
+  'LightningLeo',
+  'BlazeBella',
+  'NitroNina',
+  'DriftDerek',
+  'RallyRae',
+  'TrackTony',
+];
+
+async function generateSampleData() {
+  await seedDefaultAssists();
+
+  const passwordHash = '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi';
+
+  for (const name of sampleUsers) {
+    // eslint-disable-next-line no-await-in-loop
+    await db.query(
+      'INSERT INTO users (username, email, password_hash) VALUES ($1,$2,$3) ON CONFLICT (username) DO NOTHING',
+      [name.toLowerCase(), `${name.toLowerCase()}@example.com`, passwordHash]
+    );
+  }
+
+  const { rows: userRows } = await db.query('SELECT id, username FROM users');
+  const userMap = Object.fromEntries(userRows.map((u) => [u.username, u.id]));
+
+  const file = path.join(__dirname, '..', '..', 'database', 'sample_lap_times.json');
+  const samples = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+  const games = await db.query('SELECT id, name FROM games');
+  const trackLayouts = await db.query(`SELECT tl.id, t.name AS track, l.name AS layout
+                                       FROM track_layouts tl
+                                       JOIN tracks t ON tl.track_id = t.id
+                                       JOIN layouts l ON tl.layout_id = l.id`);
+  const cars = await db.query('SELECT id, name FROM cars');
+  const assists = await db.query('SELECT id, name FROM assists');
+
+  const gameMap = Object.fromEntries(games.rows.map((g) => [g.name, g.id]));
+  const tlMap = Object.fromEntries(trackLayouts.rows.map((r) => [`${r.track}|${r.layout}`, r.id]));
+  const carMap = Object.fromEntries(cars.rows.map((c) => [c.name, c.id]));
+  const assistMap = Object.fromEntries(assists.rows.map((a) => [a.name, a.id]));
+
+  let userIdx = 0;
+  for (const lap of samples) {
+    const userName = sampleUsers[userIdx % sampleUsers.length].toLowerCase();
+    userIdx += 1;
+    const userId = userMap[userName];
+    const gameId = gameMap[lap.game];
+    const tlId = tlMap[`${lap.track}|${lap.layout}`];
+    const carId = carMap[lap.car];
+    if (!userId || !gameId || !tlId || !carId) continue; // skip if data missing
+
+    const res = await db.query(
+      `INSERT INTO lap_times (user_id, game_id, track_layout_id, car_id, input_type, assists_json, time_ms, lap_date)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`,
+      [userId, gameId, tlId, carId, lap.inputType, JSON.stringify(lap.assists), lap.timeMs, lap.lapDate]
+    );
+    const lapId = res.rows[0].id;
+    for (const a of lap.assists) {
+      const aid = assistMap[a];
+      if (aid) {
+        // eslint-disable-next-line no-await-in-loop
+        await db.query('INSERT INTO lap_time_assists (lap_time_id, assist_id) VALUES ($1,$2)', [lapId, aid]);
+      }
+    }
+  }
+
+  console.log('Generated sample users and lap times');
+}
+
+module.exports = { generateSampleData };

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -149,3 +149,8 @@ export async function uploadGamePack(file: File) {
   });
   return res.data as { message: string; summary: { games: number; tracks: number; layouts: number; cars: number } };
 }
+
+export async function generateSampleData() {
+  const res = await apiClient.post('/admin/generateSampleData');
+  return res.data as { message: string };
+}

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -3,6 +3,7 @@ import apiClient from './client';
 export interface VersionInfo {
   appVersion: string;
   dbVersion: string;
+  sampleDataEnabled?: boolean;
 }
 
 export async function getVersion(): Promise<VersionInfo> {

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -10,6 +10,7 @@ const mockedApi = {
   getCars: jest.fn(),
   verifyLapTime: jest.fn(),
   deleteLapTime: jest.fn(),
+  generateSampleData: jest.fn(),
   getVersion: jest.fn(),
   getAdminUsers: jest.fn(),
   createUser: jest.fn(),
@@ -28,7 +29,7 @@ beforeEach(() => {
   mockedApi.getLayouts.mockResolvedValue([]);
   mockedApi.getCars.mockResolvedValue([]);
   mockedApi.getAdminUsers.mockResolvedValue([]);
-  mockedApi.getVersion.mockResolvedValue({ appVersion: 'v1.1', dbVersion: 'v1' });
+  mockedApi.getVersion.mockResolvedValue({ appVersion: 'v1.1', dbVersion: 'v1', sampleDataEnabled: true });
 });
 
 test('renders admin heading', () => {
@@ -76,4 +77,16 @@ test('deletes a lap time', async () => {
   expect(await screen.findByText('2')).toBeInTheDocument();
   await userEvent.click(screen.getAllByRole('button', { name: /delete/i })[0]);
   expect(mockedApi.deleteLapTime).toHaveBeenCalledWith('2');
+});
+
+test('generates sample data when enabled', async () => {
+  render(
+    <MemoryRouter>
+      <AdminPage />
+    </MemoryRouter>
+  );
+  await userEvent.click(screen.getByRole('button', { name: /database tools/i }));
+  const btn = await screen.findByRole('button', { name: /generate sample data/i });
+  await userEvent.click(btn);
+  expect(mockedApi.generateSampleData).toHaveBeenCalled();
 });

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -28,6 +28,7 @@ import {
   clearGameData,
   scanGamePack,
   uploadGamePack,
+  generateSampleData,
   getVersion,
   getAdminUsers,
   createUser,
@@ -52,6 +53,7 @@ const AdminPage: React.FC = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [appVersion, setAppVersion] = useState('');
   const [dbVersion, setDbVersion] = useState('');
+  const [sampleDataEnabled, setSampleDataEnabled] = useState(false);
 
   const [gameImage, setGameImage] = useState<File | null>(null);
   const [trackImage, setTrackImage] = useState<File | null>(null);
@@ -133,6 +135,7 @@ const AdminPage: React.FC = () => {
       .then((v) => {
         setAppVersion(v.appVersion);
         setDbVersion(v.dbVersion);
+        setSampleDataEnabled(!!v.sampleDataEnabled);
       })
       .catch(() => {});
   }, []);
@@ -403,6 +406,20 @@ const AdminPage: React.FC = () => {
     }
   };
 
+  const handleGenerateSamples = async () => {
+    toast.info('Generating sample data...');
+    try {
+      await generateSampleData();
+      toast.success('Sample data created');
+      refreshGames();
+      refreshTracks();
+      refreshLayouts();
+      refreshCars();
+    } catch (err) {
+      toast.error('Generation failed');
+    }
+  };
+
   return (
     <div className="container mx-auto py-6 flex">
       <aside className="w-56 pr-4 border-r space-y-6">
@@ -510,6 +527,11 @@ const AdminPage: React.FC = () => {
               <Button size="sm" variant="destructive" onClick={handleClearLapTimes}>
                 Clear All Lap Times
               </Button>
+              {sampleDataEnabled && (
+                <Button size="sm" onClick={handleGenerateSamples}>
+                  Generate Sample Data
+                </Button>
+              )}
               <div className="flex items-center space-x-2">
                 <select
                   className="border p-1"


### PR DESCRIPTION
## Summary
- add sample data generation script
- expose ENABLE_SAMPLE_DATA via version endpoint
- add admin API route and button for generating sample data
- document ENABLE_SAMPLE_DATA env variable

## Testing
- `npm test --prefix backend`
- `pnpm --dir frontend test`

------
https://chatgpt.com/codex/tasks/task_e_685be945675c8321820b315a75bfdf7a