### PR TITLE
Fix getLapTimes call signatures

### DIFF
--- a/frontend/src/pages/CarDetailPage.tsx
+++ b/frontend/src/pages/CarDetailPage.tsx
@@ -39,7 +39,7 @@ const CarDetailPage: React.FC = () => {
     getWorldRecords()
       .then((data) => setTop(data.filter((l) => l.carId === id)))
       .catch(() => {});
-    getLapTimes(undefined, id)
+    getLapTimes({ carId: id })
       .then((data) => {
         data.sort((a, b) => new Date(b.lapDate).getTime() - new Date(a.lapDate).getTime());
         setRecent(data.slice(0, 10));

--- a/frontend/src/pages/SubmitLapTimePage.tsx
+++ b/frontend/src/pages/SubmitLapTimePage.tsx
@@ -143,7 +143,7 @@ const SubmitLapTimePage: React.FC = () => {
       setRank(null);
       return;
     }
-    getLapTimes(user.id)
+    getLapTimes({ userId: user.id })
       .then((data) => {
         const filtered = data.filter(
           (t) => t.trackLayoutId === trackLayoutId && t.gameId === gameId


### PR DESCRIPTION
## Summary
- update CarDetailPage to pass filters object to `getLapTimes`
- fix SubmitLapTimePage to call `getLapTimes` with userId parameter

## Testing
- `npm test --prefix backend`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685bef5f5ef4832183ac427f1ad7f6cb