### PR TITLE
Fix Vite host configuration

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      host: '0.0.0.0',
       proxy: {
         '/uploads': {
           target: backendUrl,


### PR DESCRIPTION
## Summary
- expose Vite dev server on all interfaces

## Testing
- `npm test` in `backend`
- `pnpm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685c9e56a200832186bcb96f7219e81d