### PR TITLE
Allow preview host laps.thecartwrights.nz

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,5 +23,9 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    preview: {
+      host: '0.0.0.0',
+      allowedHosts: ['laps.thecartwrights.nz'],
+    },
   };
 });


### PR DESCRIPTION
## Summary
- allow `laps.thecartwrights.nz` host when using `vite preview`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685ca737b9448321b2c22d7b4dc83108